### PR TITLE
feat: add shared assets workspace and studio history

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,6 +43,7 @@ LICENSE
 *.pem
 *.tsbuildinfo
 public/uploads
+public/demo-assets
 *-before.png
 design-qa-*.png
 canvas-rollback-empty.png

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ package-lock.json
 
 # Runtime uploads and local QA artifacts
 /public/uploads/
+/public/demo-assets/
 /*-before.png
 /design-qa-*.png
 /canvas-rollback-empty.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Do not add authentication, accounts, payments, subscriptions, credits, API-key i
 - Storage entitlement follows billing. BeatAPI managed R2/Files is allowed only with the official `https://api.beatapi.io` billing endpoint; any custom API host must use an operator-owned R2/S3-compatible bucket. File selection stays local and upload is allowed only after generation precheck. Never commit shared storage credentials.
 - The model catalog lives in `src/core/effects/effect-registry.ts`.
 - BeatAPI request mapping lives in `src/core/adapters/beatapi-adapter.ts`.
-- Studio and Canvas share projects, tasks, and assets.
+- Studio, Canvas, and Assets share projects, tasks, and assets.
 - Add message keys to both `messages/en.json` and `messages/zh.json`.
 - Do not edit `src/routeTree.gen.ts` manually.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ Projects
   + Storage configuration
 ```
 
-Studio and Canvas are two views over the same project, generation, and asset services. Switching modes never creates a second project or backend.
+Studio, Canvas, and Assets are three views over the same project, generation, and asset services. Switching modes never creates a second project or backend.
 
 ## Runtime flow
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,11 +1,11 @@
-# Design System — BeatAPI SaaS Template
+# Design System — BeatDesign
 
 ## Product Context
 
-- **What this is:** An open-source AI SaaS starter and a working demonstration of building on BeatAPI.
+- **What this is:** An open-source, local-first AI creative workbench and a working demonstration of building on BeatAPI.
 - **Who it is for:** Independent developers and small product teams shipping AI media products for an international audience.
 - **Space:** Developer tools, AI creative software, and SaaS infrastructure.
-- **Project type:** Marketing site, authenticated SaaS dashboard, guided studio, and node canvas.
+- **Project type:** Marketing site, local project workspace, guided Studio, node Canvas, and shared Assets view.
 
 ## Aesthetic Direction
 
@@ -52,9 +52,10 @@
 ## Layout
 
 - **Marketing grid:** 12 columns, max width 1280px, 24–32px gutters.
-- **App grid:** Creative project routes use a 56px top bar and fluid main region without a persistent sidebar. Administrative routes may keep their own navigation.
-- **Studio:** No sidebar. A full-bleed media wall supports a bottom floating composer; media type, model, ratio, credits, and Generate live in that composer. Content max width is 1380px and composer max width is 1180px.
+- **App grid:** Creative project routes use a 56px top bar and fluid main region without a persistent sidebar.
+- **Studio:** No sidebar. A full-bleed media wall supports a bottom floating composer; media type, model, ratio, parameters, and Generate live in that composer. Content max width is 1380px and composer max width is 1180px.
 - **Canvas:** Full-bleed workspace inside the same AppShell. Floating toolbars use the shared panel tokens.
+- **Assets:** A project-scoped media library shares the same AppShell and content width as Studio.
 - **Responsive:** Sidebar becomes a drawer below 960px. Canvas remains usable with touch-safe controls and a collapsible inspector.
 
 ## Component Language

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,7 +11,7 @@
 
 - **Direction:** Warm technical editorial in marketing; cinematic black creative operating system across Studio, Canvas, and PromptWise-structured Pricing.
 - **Decoration:** Intentional. Typography, product media, fine grid lines, dark glass controls, and restrained highlights create character without ornamental UI noise.
-- **Layout:** Hybrid. Marketing uses editorial scale and asymmetry; authenticated product surfaces use a strict, predictable grid.
+- **Layout:** Hybrid. Marketing uses editorial scale and asymmetry; local project surfaces use a strict, predictable grid.
 - **Mood:** Capable, cinematic, and crafted. Creation surfaces should feel like focused production tools, while the marketing site stays warmer and more editorial.
 - **Reference language:** PromptWise is the visual reference, not a copied page or a separately selectable theme.
 
@@ -30,7 +30,7 @@
 - **Brand 600:** `#E9550B` — hover and pressed states.
 - **Brand soft:** `#FFF0E5` — selected surfaces and subtle callouts.
 - **Marketing canvas:** `#F6F0E7` — warm cream.
-- **Studio / Canvas canvas:** `#08090A` — near-black production workspace.
+- **Studio / Canvas / Assets canvas:** `#08090A` — near-black production workspace.
 - **Pricing canvas:** `#08090A` with graphite `#141517` plan cards, warm-white type, and PromptWise's original plan geometry.
 - **Dark surface:** `#111214`; raised surface `#17181B`; control surface `#202126`.
 - **Dark ink:** `#F6F6F4`; secondary `rgba(246,246,244,.58)`; faint `rgba(246,246,244,.34)`.
@@ -39,7 +39,7 @@
 - **Borders:** `#DDDED8`; strong `#C7C9C0`.
 - **Highlight:** `#C7F36B` — sparse proof or status accent, never a primary CTA.
 - **Success:** `#208A55`; warning `#B66A09`; error `#C23B32`; info `#2563A9`.
-- **Dark product surfaces:** Near-black canvas with charcoal cards. Orange stays saturated because it is the only brand action color; purple is limited to Canvas graph semantics. Pricing keeps PromptWise's commercial hierarchy while using the same dark product vocabulary as Studio and Canvas.
+- **Dark product surfaces:** Near-black canvas with charcoal cards. Orange stays saturated because it is the only brand action color; cold blue is limited to Canvas graph semantics. Pricing keeps PromptWise's commercial hierarchy while using the same dark product vocabulary as Studio, Canvas, and Assets.
 
 ## Spacing and Shape
 
@@ -70,11 +70,11 @@ MarketingHeader, HeroStatement, HeroDemoFrame, ProofStrip, FeatureStory, MediaSh
 
 ### Product
 
-AppShell, AppSidebar, AppTopbar, PageHeader, MetricCard, DataTable, EmptyState, ErrorState, LoadingState, UsageMeter, CreditBalance, and StatusBadge.
+AppShell, AppTopbar, PageHeader, MediaLibrary, EmptyState, ErrorState, LoadingState, and StatusBadge.
 
 ### Creative workspace
 
-WorkspaceSwitcher, PromptComposer, MediaUploader, ModelPicker, EffectPicker, GenerationSettings, GenerationCard, TaskProgress, ResultViewer, CreditEstimate, APIRequestPreview, WebhookStatus, CanvasNode, CanvasEdge, CanvasToolbar, and InspectorPanel.
+WorkspaceSwitcher, PromptComposer, MediaUploader, ModelPicker, EffectPicker, GenerationSettings, GenerationCard, GenerationHistory, TaskProgress, ResultViewer, CanvasNode, CanvasEdge, CanvasToolbar, and InspectorPanel.
 
 Do not create a universal `Section` component controlled by many presentation props. Reuse small primitives and keep each product section semantically owned.
 
@@ -84,7 +84,7 @@ React Flow remains the interaction engine. PromptWise changes its visual express
 
 - Canvas background uses the same near-black canvas with a restrained two-scale dot grid.
 - Nodes are dark, thin-bordered cards with a narrow semantic header and clear input/output ports.
-- Purple marks graph selection and connection semantics; orange remains reserved for brand and purchase actions.
+- Cold blue marks graph selection and connection semantics; orange remains reserved for brand actions.
 - Toolbars and inspectors match AppShell surfaces, typography, radius, and focus states.
 - Zoom, pan, connect, multi-select, keyboard shortcuts, undo/redo, persistence, and accessibility behavior are regression-tested independently of styling.
 
@@ -117,7 +117,7 @@ Homepage emphasis is approximately 70% what can be built with BeatAPI, 20% what 
 | Date | Decision | Rationale |
 | --- | --- | --- |
 | 2026-08-12 | One PromptWise-derived design language | A single recognizable system is more valuable than several shallow themes. |
-| 2026-08-12 | Shared AppShell with Studio and Canvas modes | Preserves both workflows without doubling dashboard maintenance. |
+| 2026-08-12 | Shared AppShell with Studio, Canvas, and Assets modes | Preserves every project view without duplicating workspace chrome. |
 | 2026-08-12 | Orange primary, cream marketing, neutral app | Connects the brand across marketing and product while preserving workspace clarity. |
 | 2026-08-12 | Figtree + Geist Mono | Keeps creative brand expression and developer readability in one family of interfaces. |
 | 2026-08-15 | Unified black Studio, Canvas, and Pricing | Pricing retains the preferred PromptWise structure while matching the cinematic product environment. |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Open `http://localhost:3020`. Home is the default route. Opening Studio or Canva
 ## How data flows
 
 ```text
-Studio / Canvas
+Studio / Canvas / Assets
   -> local server routes
   -> imported files saved under data/project-assets and indexed in SQLite
   -> generation precheck and a one-time SQLite generation intent

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ There is no login, account system, payment flow, subscription, local credit ledg
 
 - Studio for prompt-first image and video generation.
 - React Flow Canvas for connected, multi-step creative workflows.
+- A project-scoped Assets view shared by Studio and Canvas.
 - Local projects, snapshots, generation history, and asset indexing.
 - One code-defined catalog of supported BeatAPI image and video models.
 - BeatAPI task submission and status polling.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,6 +10,7 @@
 
 - Studio：以提示词和参数为主的快速生成体验。
 - Canvas：基于 React Flow 的多步骤节点画布。
+- Assets：Studio 与 Canvas 共用的项目素材库。
 - 本地项目、画布快照、生成历史和素材索引。
 - 由代码统一维护的 BeatAPI 图片/视频模型目录。
 - BeatAPI 任务提交、状态轮询和结果回填。
@@ -35,7 +36,7 @@ pnpm dev
 ## 数据逻辑
 
 ```text
-Studio / Canvas
+Studio / Canvas / Assets
   -> 本地服务端接口
   -> 导入文件立即保存到 data/project-assets，并写入 SQLite 素材索引
   -> 生成预检与 SQLite 一次性生成意图

--- a/WORKSPACE_MODES.md
+++ b/WORKSPACE_MODES.md
@@ -1,13 +1,15 @@
 # Workspace modes
 
-Each project can be opened in either mode:
+Each project can be opened in three modes:
 
 - **Studio** is a guided, form-first surface for producing a result quickly.
 - **Canvas** is a node-based surface for connected references and multi-step workflows.
+- **Assets** is the project-scoped library shared by Studio and Canvas.
 
-Both modes share the same project ID, assets, model catalog, provider connection, generation history, and persistence layer. The last opened mode is stored on the project so the project list can resume in place.
+All three modes share the same project ID, assets, model catalog, provider connection, generation history, and persistence layer. The last opened mode is stored on the project so the project list can resume in place.
 
 Routes:
 
 - `/studio/:projectId`
 - `/canvas/:projectId`
+- `/assets/:projectId`

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "product.shell.home": "Home",
+  "product.shell.create": "Create",
   "product.shell.studio": "Studio",
   "product.shell.canvas": "Canvas",
   "product.shell.pricing": "Pricing",
@@ -21,10 +22,10 @@
   "product.home.createInStudio": "Create in Studio",
   "product.home.sectionTitle": "Choose your workspace",
   "product.home.viewProjects": "View projects",
-  "product.home.studioDescription": "Generate and compare images or videos in a focused workspace.",
-  "product.home.canvasDescription": "Arrange shared assets and connect them into a visual workflow.",
+  "product.home.studioDescription": "Generate images and videos in one workspace.",
+  "product.home.canvasDescription": "Connect assets in a visual workflow.",
   "product.home.projectsTitle": "Projects",
-  "product.home.projectsDescription": "Continue recent work with Studio and Canvas state kept together.",
+  "product.home.projectsDescription": "Continue recent Studio and Canvas work.",
   "product.home.openWorkspace": "Open workspace",
   "product.home.mediaImage": "Image",
   "product.home.mediaVideo": "Video",
@@ -387,7 +388,8 @@
           "status": {
             "queued": "Queued",
             "generating": "Generating",
-            "ready": "Ready",
+        "ready": "Success",
+        "success": "Success",
             "failed": "Failed"
           },
           "fromCanvas": "From canvas",
@@ -431,6 +433,23 @@
         "guideDescription": "Generate freely from a prompt, or upload an image to start.",
         "freeGenerate": "Free generation",
         "uploadStart": "Upload image"
+      },
+      "feed": {
+        "history": "History",
+        "result": "Generation",
+        "generating": "Generating...",
+        "failed": "Failed",
+        "ready": "Ready",
+        "success": "Success",
+        "noPrompt": "No prompt",
+        "openPreview": "Open preview",
+        "closePreview": "Close preview",
+        "prompt": "Prompt",
+        "model": "Model",
+        "params": "Parameters",
+        "image": "Image",
+        "video": "Video",
+        "references": "References"
       },
       "textNote": {
         "template": "Text note\n\nCapture composition ideas, shot notes, or production reminders here."
@@ -624,10 +643,9 @@
       "retry": "Try again",
       "backToHistory": "Back to history",
       "startTitle": "Start a new project",
-      "startStudioDescription": "A Studio project is created only after you choose to start.",
-      "startCanvasDescription": "A Canvas project is created only after you choose to start.",
-      "startStudio": "Start Studio project",
-      "startCanvas": "Start Canvas project",
+      "startDescription": "Choose Studio or Canvas to create this project.",
+      "startStudio": "Studio",
+      "startCanvas": "Canvas",
       "defaultName": "Untitled project"
     }
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "product.shell.home": "首页",
+  "product.shell.create": "创作",
   "product.shell.studio": "Studio",
   "product.shell.canvas": "Canvas",
   "product.shell.pricing": "定价",
@@ -22,10 +23,10 @@
   "product.home.createInStudio": "在 Studio 中创作",
   "product.home.sectionTitle": "选择你的工作空间",
   "product.home.viewProjects": "查看项目",
-  "product.home.studioDescription": "在专注的工作区中生成和比较图片或视频。",
-  "product.home.canvasDescription": "排列共享素材，并把它们连接成可视化工作流。",
+  "product.home.studioDescription": "在专注工作区生成图片和视频。",
+  "product.home.canvasDescription": "把素材连成可视化工作流。",
   "product.home.projectsTitle": "项目",
-  "product.home.projectsDescription": "继续最近的创作，Studio 与 Canvas 状态会保存在同一个项目中。",
+  "product.home.projectsDescription": "继续最近的 Studio 与 Canvas 创作。",
   "product.home.openWorkspace": "打开工作空间",
   "product.home.mediaImage": "图片",
   "product.home.mediaVideo": "视频",
@@ -389,6 +390,7 @@
             "queued": "排队中",
             "generating": "生成中",
             "ready": "已就绪",
+            "success": "成功",
             "failed": "失败"
           },
           "fromCanvas": "来自画布",
@@ -432,6 +434,23 @@
         "guideDescription": "用提示词自由生成，或上传图片开始创作。",
         "freeGenerate": "自由生成",
         "uploadStart": "上传图片"
+      },
+      "feed": {
+        "history": "历史",
+        "result": "生成结果",
+        "generating": "生成中...",
+        "failed": "失败",
+        "ready": "成功",
+        "success": "成功",
+        "noPrompt": "无提示词",
+        "openPreview": "打开预览",
+        "closePreview": "关闭预览",
+        "prompt": "提示词",
+        "model": "模型",
+        "params": "参数",
+        "image": "图片",
+        "video": "视频",
+        "references": "参考图"
       },
       "textNote": {
         "template": "文本备注\n\n在这里记录构图想法、镜头说明或制作备注。"
@@ -625,10 +644,9 @@
       "retry": "重试",
       "backToHistory": "返回历史",
       "startTitle": "开始新项目",
-      "startStudioDescription": "只有确认开始后，才会创建 Studio 项目。",
-      "startCanvasDescription": "只有确认开始后，才会创建 Canvas 项目。",
-      "startStudio": "开始 Studio 项目",
-      "startCanvas": "开始 Canvas 项目",
+      "startDescription": "选择 Studio 或 Canvas 来创建这个项目。",
+      "startStudio": "Studio",
+      "startCanvas": "Canvas",
       "defaultName": "未命名项目"
     }
   },

--- a/src/components/app/create-project-route-page.test.ts
+++ b/src/components/app/create-project-route-page.test.ts
@@ -9,7 +9,9 @@ const source = readFileSync(
 
 test('visiting Studio or Canvas does not create a project automatically', () => {
   assert.doesNotMatch(source, /useEffect/);
-  assert.match(source, /onClick=\{\(\) => void createProject\(\)\}/);
+  assert.match(source, /createProject\('studio'\)/);
+  assert.match(source, /createProject\('canvas'\)/);
+  assert.match(source, /envConfigs\.app_logo/);
   assert.match(source, /'\/api\/app\/projects'/);
 });
 

--- a/src/components/app/create-project-route-page.tsx
+++ b/src/components/app/create-project-route-page.tsx
@@ -1,15 +1,10 @@
 import { useState } from 'react';
-import {
-  AlertCircleIcon,
-  LayoutPanelTopIcon,
-  Loader2Icon,
-  WorkflowIcon,
-} from 'lucide-react';
+import { AlertCircleIcon, Loader2Icon } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import { envConfigs } from '@/config';
 import type { WorkspaceMode } from '@/config/workspace-modes';
 import { buildPostCreateProjectDetailPath } from '@/core/projects/project-entry';
-import { useLocaleRouter } from '@/core/i18n/navigation';
 import { apiJsonPost } from '@/lib/api-client';
 import { m } from '@/paraglide/messages.js';
 
@@ -41,13 +36,8 @@ function getCopy(locale: string) {
       { locale: messageLocale }
     ),
     retry: m['BeatAPI.project.retry']({}, { locale: messageLocale }),
-    back: m['BeatAPI.project.backToHistory']({}, { locale: messageLocale }),
     startTitle: m['BeatAPI.project.startTitle']({}, { locale: messageLocale }),
-    startStudioDescription: m['BeatAPI.project.startStudioDescription'](
-      {},
-      { locale: messageLocale }
-    ),
-    startCanvasDescription: m['BeatAPI.project.startCanvasDescription'](
+    startDescription: m['BeatAPI.project.startDescription'](
       {},
       { locale: messageLocale }
     ),
@@ -67,20 +57,12 @@ export function CreateProjectRoutePage({
 }: {
   data: CreateProjectRouteData;
 }) {
-  const {
-    locale,
-    target,
-    model,
-    prompt,
-    workspaceMode,
-    projectName,
-  } = data;
-  const router = useLocaleRouter();
+  const { locale, target, model, prompt, projectName } = data;
   const copy = getCopy(locale);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function createProject() {
+  async function createProject(workspaceMode: WorkspaceMode) {
     if (creating) return;
     setCreating(true);
     setError(null);
@@ -113,13 +95,6 @@ export function CreateProjectRoutePage({
     }
   }
 
-  const isStudio = workspaceMode === 'studio';
-  const description = isStudio
-    ? copy.startStudioDescription
-    : copy.startCanvasDescription;
-  const startLabel = isStudio ? copy.startStudio : copy.startCanvas;
-  const WorkspaceIcon = isStudio ? LayoutPanelTopIcon : WorkflowIcon;
-
   return (
     <main className="flex min-h-screen items-center justify-center bg-[var(--beat-bg)] px-6 py-16 text-[var(--beat-text-1)]">
       <section className="w-full max-w-[520px] rounded-[var(--beat-radius)] border border-white/[0.13] bg-[linear-gradient(145deg,#1b1b1e_0%,#151517_100%)] px-8 py-9 text-center shadow-[0_30px_100px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.035)]">
@@ -132,35 +107,49 @@ export function CreateProjectRoutePage({
             <Loader2Icon className="size-6 animate-spin" />
           </div>
         ) : (
-          <div className="mx-auto flex size-12 items-center justify-center rounded-full border border-[rgba(255,122,51,0.24)] bg-[rgba(255,122,51,0.10)] text-[var(--beat-accent)]">
-            <WorkspaceIcon className="size-5" />
-          </div>
+          <img
+            src={envConfigs.app_logo}
+            alt={envConfigs.app_name}
+            className="mx-auto size-12 rounded-[14px] object-contain"
+          />
         )}
 
-        <h1 className="mt-5 text-[28px] font-semibold tracking-[-0.045em]">
+        <h1 className="beat-product-display mt-5 text-[28px] font-semibold tracking-[-0.045em]">
           {error ? copy.errorTitle : creating ? copy.title : copy.startTitle}
         </h1>
         <p className="mt-3 text-[15px] leading-7 text-[var(--beat-text-2)]">
-          {error || (creating ? copy.description : description)}
+          {error || (creating ? copy.description : copy.startDescription)}
         </p>
 
         {!creating ? (
           <div className="mt-7 flex flex-col gap-2 sm:flex-row sm:justify-center">
-            <Button
-              type="button"
-              className="h-11 rounded-[var(--beat-radius-sm)] bg-[var(--beat-accent)] px-5 text-[var(--beat-accent-ink)] hover:bg-[var(--beat-accent-hover)]"
-              onClick={() => void createProject()}
-            >
-              {error ? copy.retry : startLabel}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              className="h-11 rounded-[16px] border-white/[0.16] bg-transparent px-5 text-white hover:bg-white/[0.06]"
-              onClick={() => router.replace('/projects')}
-            >
-              {copy.back}
-            </Button>
+            {error ? (
+              <Button
+                type="button"
+                className="h-11 rounded-[var(--beat-radius-sm)] bg-[var(--beat-accent)] px-5 text-[var(--beat-accent-ink)] hover:bg-[var(--beat-accent-hover)]"
+                onClick={() => void createProject('studio')}
+              >
+                {copy.retry}
+              </Button>
+            ) : (
+              <>
+                <Button
+                  type="button"
+                  className="h-11 rounded-[var(--beat-radius-sm)] bg-[var(--beat-accent)] px-5 text-[var(--beat-accent-ink)] hover:bg-[var(--beat-accent-hover)]"
+                  onClick={() => void createProject('studio')}
+                >
+                  {copy.startStudio}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-11 rounded-[16px] border-white/[0.16] bg-transparent px-5 text-white hover:bg-white/[0.06]"
+                  onClick={() => void createProject('canvas')}
+                >
+                  {copy.startCanvas}
+                </Button>
+              </>
+            )}
           </div>
         ) : null}
       </section>

--- a/src/components/app/product-page-shell-title.test.ts
+++ b/src/components/app/product-page-shell-title.test.ts
@@ -9,6 +9,7 @@ test('project title field uses the available header width instead of a short cha
   );
 
   assert.doesNotMatch(source, /20\)\}ch/);
+  assert.doesNotMatch(source, /maxLength=/);
   assert.match(source, /className="flex min-w-0 flex-1 items-center gap-3"/);
   assert.match(source, /className="min-w-0 flex-1"/);
   assert.match(source, /className="h-9 w-full/);

--- a/src/components/app/product-page-shell.test.ts
+++ b/src/components/app/product-page-shell.test.ts
@@ -18,7 +18,8 @@ const apiConfigSource = readFileSync(
 
 test('workspace header keeps mode switching, shared assets, and API configuration actions', () => {
   assert.match(shellSource, /WorkspaceApiConfigDialog/);
-  assert.match(shellSource, /ProjectAssetsDialog/);
+  assert.match(shellSource, /\/assets\//);
+  assert.match(shellSource, />Assets<\/span>/);
   assert.match(shellSource, /GitHubIcon/);
   assert.match(
     shellSource,

--- a/src/components/app/product-page-shell.tsx
+++ b/src/components/app/product-page-shell.tsx
@@ -2,10 +2,9 @@
 
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { LayoutPanelTop, Workflow } from 'lucide-react';
+import { Images, LayoutPanelTop, Workflow } from 'lucide-react';
 
 import { WorkspaceApiConfigDialog } from '@/components/app/workspace-api-config-dialog';
-import { ProjectAssetsDialog } from '@/components/app/project-assets-dialog';
 import { GitHubIcon } from '@/components/icons/github';
 import { Link } from '@/core/i18n/navigation';
 import { useTranslations } from '@/core/workspace-lib/shims/next-intl';
@@ -99,7 +98,7 @@ export function ProductPageShell({
         }
       }}
       aria-label={t('header.workspaceNameLabel')}
-      className="h-9 w-full min-w-0 rounded-md border-0 bg-transparent px-0 text-[15px] font-semibold text-[var(--beat-text-1)] outline-none placeholder:text-white/35 focus:ring-0"
+      className="h-9 w-full min-w-0 truncate rounded-md border-0 bg-transparent px-0 text-[15px] font-semibold text-[var(--beat-text-1)] outline-none placeholder:text-white/35 focus:ring-0"
     />
   ) : (
     <span className="block truncate text-[15px] font-semibold text-[var(--beat-text-1)]">
@@ -154,13 +153,18 @@ export function ProductPageShell({
                   >
                     <Workflow className="size-3.5" /> <span className="hidden sm:inline">Canvas</span>
                   </Link>
+                  <Link
+                    href={`/assets/${projectId}`}
+                    aria-current={workspaceMode === 'assets' ? 'page' : undefined}
+                    className={`inline-flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition sm:px-3 ${
+                      workspaceMode === 'assets'
+                        ? 'bg-white/[0.10] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]'
+                        : 'text-[var(--beat-text-2)] hover:text-white'
+                    }`}
+                  >
+                    <Images className="size-3.5" /> <span className="hidden sm:inline">Assets</span>
+                  </Link>
                 </div>
-              ) : null}
-              {projectId ? (
-                <ProjectAssetsDialog
-                  projectId={projectId}
-                  canAddToCanvas={workspaceMode === 'canvas'}
-                />
               ) : null}
               <WorkspaceApiConfigDialog
                 providerId={envConfigs.generation_provider}

--- a/src/components/app/project-assets-dialog.tsx
+++ b/src/components/app/project-assets-dialog.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/core/workspace-lib/app/workspace-client-api';
 import { recentAssetsKeys } from '@/core/workspace-lib/app/workspace-query-keys';
 import { useTranslations } from '@/core/workspace-lib/shims/next-intl';
+import { beatPanelLabelClassName } from '@/components/app/composer-styles';
 import {
   PROJECT_ASSET_DRAG_MIME,
   PROJECT_ASSET_INSERT_EVENT,
@@ -83,7 +84,7 @@ function AssetTile({
       onDragEnd={(event) => {
         if (event.dataTransfer.dropEffect === 'copy') onAdded();
       }}
-      className={`group relative aspect-square overflow-hidden rounded-[14px] border border-white/[0.08] bg-[#09090b] transition hover:-translate-y-0.5 hover:border-white/[0.22] ${
+      className={`group relative h-[200px] w-fit overflow-hidden rounded-[14px] bg-transparent transition hover:-translate-y-0.5 ${
         canAddToCanvas ? 'cursor-grab active:cursor-grabbing' : ''
       }`}
       title={asset.filename || addLabel}
@@ -94,13 +95,13 @@ function AssetTile({
           muted
           playsInline
           preload="metadata"
-          className="size-full object-cover opacity-85 transition duration-300 group-hover:opacity-100"
+          className="h-full w-auto object-contain"
         />
       ) : (
         <img
           src={asset.publicUrl}
           alt={asset.filename || ''}
-          className="size-full object-cover transition duration-300 group-hover:scale-[1.025]"
+          className="h-full w-auto object-contain"
         />
       )}
       {mediaType === 'video' ? (
@@ -148,6 +149,102 @@ function AssetTile({
   );
 }
 
+export function ProjectAssetsLibrary({
+  projectId,
+  canAddToCanvas = false,
+  onAdded,
+}: {
+  projectId: string;
+  canAddToCanvas?: boolean;
+  onAdded?: () => void;
+}) {
+  const t = useTranslations('AppShell.header.projectAssets');
+  const assetsQuery = useQuery({
+    queryKey: recentAssetsKeys.lists(projectId),
+    queryFn: () => fetchRecentAssets(projectId),
+    staleTime: 30 * 1000,
+  });
+  const images = assetsQuery.data?.images ?? [];
+  const videos = assetsQuery.data?.videos ?? [];
+  const total = images.length + videos.length;
+
+  return (
+    <>
+      {assetsQuery.isLoading ? (
+        <div className="flex min-h-52 items-center justify-center gap-2 text-[13px] text-white/45">
+          <Loader2 className="size-4 animate-spin" />
+          {t('loading')}
+        </div>
+      ) : null}
+
+      {assetsQuery.isError ? (
+        <div className="flex min-h-52 items-center justify-center text-[13px] text-[#ff8a8d]">
+          {t('loadFailed')}
+        </div>
+      ) : null}
+
+      {!assetsQuery.isLoading && !assetsQuery.isError && total === 0 ? (
+        <div className="flex min-h-52 flex-col items-center justify-center text-center">
+          <span className="grid size-12 place-items-center rounded-[15px] border border-white/[0.08] bg-white/[0.035] text-white/28">
+            <Images className="size-5" />
+          </span>
+          <p className="mt-4 text-[14px] font-medium text-white/72">
+            {t('empty')}
+          </p>
+        </div>
+      ) : null}
+
+      {!assetsQuery.isLoading && !assetsQuery.isError && total > 0 ? (
+        <div className="space-y-6">
+          {images.length > 0 ? (
+            <section>
+              <h3 className={`mb-3 ${beatPanelLabelClassName}`}>
+                {t('images')}
+              </h3>
+              <div className="flex flex-wrap gap-3">
+                {images.map((asset) => (
+                  <AssetTile
+                    key={asset.id}
+                    asset={asset}
+                    mediaType="image"
+                    projectId={projectId}
+                    canAddToCanvas={canAddToCanvas}
+                    onAdded={() => onAdded?.()}
+                    addLabel={t('addToCanvas')}
+                    openLabel={t('openOriginal')}
+                  />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {videos.length > 0 ? (
+            <section>
+              <h3 className={`mb-3 ${beatPanelLabelClassName}`}>
+                {t('videos')}
+              </h3>
+              <div className="flex flex-wrap gap-3">
+                {videos.map((asset) => (
+                  <AssetTile
+                    key={asset.id}
+                    asset={asset}
+                    mediaType="video"
+                    projectId={projectId}
+                    canAddToCanvas={canAddToCanvas}
+                    onAdded={() => onAdded?.()}
+                    addLabel={t('addToCanvas')}
+                    openLabel={t('openOriginal')}
+                  />
+                ))}
+              </div>
+            </section>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
 export function ProjectAssetsDialog({
   projectId,
   canAddToCanvas = false,
@@ -157,14 +254,6 @@ export function ProjectAssetsDialog({
 }) {
   const t = useTranslations('AppShell.header.projectAssets');
   const [open, setOpen] = useState(false);
-  const assetsQuery = useQuery({
-    queryKey: recentAssetsKeys.lists(projectId),
-    queryFn: () => fetchRecentAssets(projectId),
-    staleTime: 30 * 1000,
-  });
-  const images = assetsQuery.data?.images ?? [];
-  const videos = assetsQuery.data?.videos ?? [];
-  const total = images.length + videos.length;
 
   return (
     <Dialog modal={false} open={open} onOpenChange={setOpen}>
@@ -177,11 +266,6 @@ export function ProjectAssetsDialog({
         <span className="hidden text-xs font-medium sm:inline">
           {t('triggerLabel')}
         </span>
-        {total > 0 ? (
-          <span className="text-[10px] font-semibold tabular-nums text-white/38">
-            {total}
-          </span>
-        ) : null}
       </DialogTrigger>
 
       <DialogContent
@@ -207,77 +291,11 @@ export function ProjectAssetsDialog({
         </DialogHeader>
 
         <div className="max-h-[60vh] overflow-y-auto px-5 py-5 sm:px-6">
-          {assetsQuery.isLoading ? (
-            <div className="flex min-h-52 items-center justify-center gap-2 text-[13px] text-white/45">
-              <Loader2 className="size-4 animate-spin" />
-              {t('loading')}
-            </div>
-          ) : null}
-
-          {assetsQuery.isError ? (
-            <div className="flex min-h-52 items-center justify-center text-[13px] text-[#ff8a8d]">
-              {t('loadFailed')}
-            </div>
-          ) : null}
-
-          {!assetsQuery.isLoading && !assetsQuery.isError && total === 0 ? (
-            <div className="flex min-h-52 flex-col items-center justify-center text-center">
-              <span className="grid size-12 place-items-center rounded-[15px] border border-white/[0.08] bg-white/[0.035] text-white/28">
-                <Images className="size-5" />
-              </span>
-              <p className="mt-4 text-[14px] font-medium text-white/72">
-                {t('empty')}
-              </p>
-            </div>
-          ) : null}
-
-          {!assetsQuery.isLoading && !assetsQuery.isError && total > 0 ? (
-            <div className="space-y-6">
-              {images.length > 0 ? (
-                <section>
-                  <h3 className="mb-3 text-[10px] font-semibold uppercase tracking-[0.15em] text-white/35">
-                    {t('images')}
-                  </h3>
-                  <div className="grid grid-cols-3 gap-2.5 sm:grid-cols-4 md:grid-cols-5">
-                    {images.map((asset) => (
-                      <AssetTile
-                        key={asset.id}
-                        asset={asset}
-                        mediaType="image"
-                        projectId={projectId}
-                        canAddToCanvas={canAddToCanvas}
-                        onAdded={() => setOpen(false)}
-                        addLabel={t('addToCanvas')}
-                        openLabel={t('openOriginal')}
-                      />
-                    ))}
-                  </div>
-                </section>
-              ) : null}
-
-              {videos.length > 0 ? (
-                <section>
-                  <h3 className="mb-3 text-[10px] font-semibold uppercase tracking-[0.15em] text-white/35">
-                    {t('videos')}
-                  </h3>
-                  <div className="grid grid-cols-3 gap-2.5 sm:grid-cols-4 md:grid-cols-5">
-                    {videos.map((asset) => (
-                      <AssetTile
-                        key={asset.id}
-                        asset={asset}
-                        mediaType="video"
-                        projectId={projectId}
-                        canAddToCanvas={canAddToCanvas}
-                        onAdded={() => setOpen(false)}
-                        addLabel={t('addToCanvas')}
-                        openLabel={t('openOriginal')}
-                      />
-                    ))}
-                  </div>
-                </section>
-              ) : null}
-            </div>
-          ) : null}
+          <ProjectAssetsLibrary
+            projectId={projectId}
+            canAddToCanvas={canAddToCanvas}
+            onAdded={() => setOpen(false)}
+          />
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/app/project-assets-workspace.tsx
+++ b/src/components/app/project-assets-workspace.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { ProjectAssetsLibrary } from '@/components/app/project-assets-dialog';
+import { useTranslations } from '@/core/workspace-lib/shims/next-intl';
+
+export function ProjectAssetsWorkspace({ projectId }: { projectId: string }) {
+  const t = useTranslations('AppShell.header.projectAssets');
+
+  return (
+    <section className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--beat-bg)] text-[var(--beat-text-1)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_112%,rgba(255,122,51,0.12),transparent_34%),linear-gradient(180deg,#08090a_0%,#0b0b0d_48%,#08090a_100%)]" />
+      <div className="relative min-h-0 flex-1 overflow-y-auto px-4 py-8 sm:px-6">
+        <div className="mx-auto w-full max-w-[1138px]">
+          <h1 className="beat-product-display text-[1.35rem] font-semibold tracking-[-0.03em] text-[var(--beat-text-1)]">
+            {t('title')}
+          </h1>
+          <p className="mt-2 whitespace-nowrap text-[13px] leading-6 text-[var(--beat-text-3)]">
+            {t('description')}
+          </p>
+          <div className="mt-8">
+            <ProjectAssetsLibrary projectId={projectId} />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/app/workspace-project-hub.tsx
+++ b/src/components/app/workspace-project-hub.tsx
@@ -17,7 +17,7 @@ import { startTransition, useDeferredValue, useMemo, useState } from 'react';
 export type WorkspaceProjectCardItem = {
   id: string;
   name: string;
-  lastWorkspaceMode?: 'studio' | 'canvas';
+  lastWorkspaceMode?: 'studio' | 'canvas' | 'assets';
   activityAt: string;
   activityLabel: string;
   coverImageUrl?: string | null;

--- a/src/components/app/workspace-project-route-page.tsx
+++ b/src/components/app/workspace-project-route-page.tsx
@@ -1,4 +1,5 @@
 import { ProductPageShell } from '@/components/app/product-page-shell';
+import { ProjectAssetsWorkspace } from '@/components/app/project-assets-workspace';
 import { BeatStudioWorkspace } from '@/components/studio/beat-studio-workspace';
 import { BeatCanvasShell } from '@/components/beatcanvas/beatcanvas-shell';
 import type { loadWorkspaceProjectRoute } from '@/core/projects/workspace-project-route-loader';
@@ -25,6 +26,8 @@ export function WorkspaceProjectRoutePage({
           initialModelId={data.modelId}
           initialPrompt={data.prompt}
         />
+      ) : data.workspaceMode === 'assets' ? (
+        <ProjectAssetsWorkspace projectId={data.project.id} />
       ) : (
         <BeatCanvasShell
           projectId={data.project.id}

--- a/src/components/beatcanvas/beatcanvas-shell.tsx
+++ b/src/components/beatcanvas/beatcanvas-shell.tsx
@@ -44,6 +44,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from '@/core/workspace-lib/shims/next-intl';
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { useCanvasComposerLabels } from './use-canvas-composer-labels';
 import { useProjectSnapshotLifecycle } from './use-project-snapshot-lifecycle';
 import { useBeatCanvasGraph } from './use-beatcanvas-graph';
 import { useBeatCanvasDraftActions } from './use-beatcanvas-draft-actions';
@@ -695,95 +696,7 @@ export function BeatCanvasShell({
     [canvasCards, selectedCanvasCardIds]
   );
 
-  const canvasCopy = useMemo(
-    () => ({
-      imageTitle: studioT('canvas.frame.imageTitle'),
-      videoTitle: studioT('canvas.frame.videoTitle'),
-      imageModeLabel: studioT('canvas.composer.imageMode'),
-      videoModeLabel: studioT('canvas.composer.videoMode'),
-      createGenerationCardLabel: studioT('canvas.connector.createGeneration'),
-      createImageGenerationCardLabel: studioT(
-        'canvas.connector.createImageGeneration'
-      ),
-      createVideoGenerationCardLabel: studioT(
-        'canvas.connector.createVideoGeneration'
-      ),
-      connectorUploadLabel: studioT('canvas.connector.upload'),
-      imagePromptPlaceholder: studioT('canvas.frame.imagePromptPlaceholder'),
-      videoPromptPlaceholder: studioT('canvas.frame.videoPromptPlaceholder'),
-      zoomLabel: studioT('canvas.zoom.label'),
-      zoomOutLabel: studioT('canvas.zoom.zoomOut'),
-      zoomInLabel: studioT('canvas.zoom.zoomIn'),
-      selectToolLabel: studioT('canvas.zoom.select'),
-      panToolLabel: studioT('canvas.zoom.pan'),
-      fitViewLabel: studioT('canvas.zoom.fitView'),
-      hideEdgesLabel: studioT('canvas.zoom.hideEdges'),
-      showEdgesLabel: studioT('canvas.zoom.showEdges'),
-      snapToGridLabel: studioT('canvas.zoom.snapToGrid'),
-      undoLabel: studioT('canvas.zoom.undo'),
-      redoLabel: studioT('canvas.zoom.redo'),
-      historyLabel: studioT('canvas.shapes.history'),
-      latestResultLabel: studioT('canvas.shapes.latestResult'),
-      emptyStateTitle: studioT('emptyState.title'),
-      emptyStateDescription: studioT('emptyState.description'),
-      emptyGuideTitle: studioT('emptyState.guideTitle'),
-      emptyGuideDescription: studioT('emptyState.guideDescription'),
-      emptyFreeGenerateLabel: studioT('emptyState.freeGenerate'),
-      emptyUploadStartLabel: studioT('emptyState.uploadStart'),
-      typeLabel: studioT('canvas.composer.type'),
-      modelLabel: studioT('single.labels.model'),
-      parameterLabel: studioT('canvas.composer.parameters'),
-      aspectRatioLabel: studioT('single.labels.aspectRatio'),
-      outputQualityLabel: studioT('single.labels.outputQuality'),
-      durationLabel: studioT('single.labels.duration'),
-      characterOrientationLabel: studioT(
-        'canvas.composer.characterOrientation'
-      ),
-      backgroundSourceLabel: studioT('canvas.composer.backgroundSource'),
-      languageLabel: studioT('canvas.composer.language'),
-      uploadImageLabel: studioT('actions.uploadImage'),
-      uploadVideoLabel: studioT('actions.uploadVideo'),
-      fromCanvasLabel: studioT('canvas.composer.fromCanvas'),
-      currentReferencesLabel: studioT('canvas.composer.currentReferences'),
-      noCanvasReferencesLabel: studioT('canvas.composer.noCanvasReferences'),
-      removeReferenceLabel: studioT('canvas.composer.removeReference'),
-      generateLabel: studioT('canvas.composer.generate'),
-      regenerateLabel: studioT('canvas.composer.regenerate'),
-      generatingLabel: studioT('canvas.composer.generating'),
-      closeComposerLabel: studioT('canvas.composer.close'),
-      defaultSetupLabel: studioT('canvas.composer.defaultSetup'),
-      modeOptionLabel: studioT('canvas.composer.mode'),
-      variantOptionLabel: studioT('canvas.composer.variant'),
-      qualityOptionLabel: studioT('canvas.composer.quality'),
-      tokenQualityLabel: studioT('canvas.composer.tokens.quality'),
-      tokenFastLabel: studioT('canvas.composer.tokens.fast'),
-      tokenLiteLabel: studioT('canvas.composer.tokens.lite'),
-      tokenLowLabel: studioT('canvas.composer.tokens.low'),
-      tokenMediumLabel: studioT('canvas.composer.tokens.medium'),
-      tokenStandardLabel: studioT('canvas.composer.tokens.standard'),
-      tokenHighLabel: studioT('canvas.composer.tokens.high'),
-      tokenProLabel: studioT('canvas.composer.tokens.pro'),
-      tokenAdaptiveLabel: studioT('canvas.composer.tokens.adaptive'),
-      tokenAutoLabel: studioT('canvas.composer.tokens.auto'),
-      tokenLandscapeLabel: studioT('canvas.composer.tokens.landscape'),
-      tokenPortraitLabel: studioT('canvas.composer.tokens.portrait'),
-      tokenChineseLabel: studioT('canvas.composer.tokens.chinese'),
-      tokenEnglishLabel: studioT('canvas.composer.tokens.english'),
-      tokenImageOrientationLabel: studioT(
-        'canvas.composer.tokens.imageOrientation'
-      ),
-      tokenVideoOrientationLabel: studioT(
-        'canvas.composer.tokens.videoOrientation'
-      ),
-      tokenInputImageLabel: studioT('canvas.composer.tokens.inputImage'),
-      tokenInputVideoLabel: studioT('canvas.composer.tokens.inputVideo'),
-      queuedStatusLabel: studioT('canvas.composer.status.queued'),
-      generatingStatusLabel: studioT('canvas.composer.status.generating'),
-      readyStatusLabel: studioT('canvas.composer.status.ready'),
-      failedStatusLabel: studioT('canvas.composer.status.failed'),
-    }),
-    [studioT]
-  );
+  const canvasCopy = useCanvasComposerLabels();
 
   const canvasComponents = useMemo(
     () => ({

--- a/src/components/beatcanvas/use-canvas-composer-labels.ts
+++ b/src/components/beatcanvas/use-canvas-composer-labels.ts
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+
+import { useTranslations } from '@/core/workspace-lib/shims/next-intl';
+
+import type { CanvasLabels } from './beatcanvas-front-layer-context';
+
+export function useCanvasComposerLabels(): CanvasLabels {
+  const studioT = useTranslations('AppShell.studio');
+
+  return useMemo(
+    () => ({
+      imageTitle: studioT('canvas.frame.imageTitle'),
+      videoTitle: studioT('canvas.frame.videoTitle'),
+      imageModeLabel: studioT('canvas.composer.imageMode'),
+      videoModeLabel: studioT('canvas.composer.videoMode'),
+      createGenerationCardLabel: studioT('canvas.connector.createGeneration'),
+      createImageGenerationCardLabel: studioT(
+        'canvas.connector.createImageGeneration'
+      ),
+      createVideoGenerationCardLabel: studioT(
+        'canvas.connector.createVideoGeneration'
+      ),
+      connectorUploadLabel: studioT('canvas.connector.upload'),
+      imagePromptPlaceholder: studioT('canvas.frame.imagePromptPlaceholder'),
+      videoPromptPlaceholder: studioT('canvas.frame.videoPromptPlaceholder'),
+      zoomLabel: studioT('canvas.zoom.label'),
+      zoomOutLabel: studioT('canvas.zoom.zoomOut'),
+      zoomInLabel: studioT('canvas.zoom.zoomIn'),
+      selectToolLabel: studioT('canvas.zoom.select'),
+      panToolLabel: studioT('canvas.zoom.pan'),
+      fitViewLabel: studioT('canvas.zoom.fitView'),
+      hideEdgesLabel: studioT('canvas.zoom.hideEdges'),
+      showEdgesLabel: studioT('canvas.zoom.showEdges'),
+      snapToGridLabel: studioT('canvas.zoom.snapToGrid'),
+      undoLabel: studioT('canvas.zoom.undo'),
+      redoLabel: studioT('canvas.zoom.redo'),
+      historyLabel: studioT('canvas.shapes.history'),
+      latestResultLabel: studioT('canvas.shapes.latestResult'),
+      emptyStateTitle: studioT('emptyState.title'),
+      emptyStateDescription: studioT('emptyState.description'),
+      emptyGuideTitle: studioT('emptyState.guideTitle'),
+      emptyGuideDescription: studioT('emptyState.guideDescription'),
+      emptyFreeGenerateLabel: studioT('emptyState.freeGenerate'),
+      emptyUploadStartLabel: studioT('emptyState.uploadStart'),
+      typeLabel: studioT('canvas.composer.type'),
+      modelLabel: studioT('single.labels.model'),
+      parameterLabel: studioT('canvas.composer.parameters'),
+      aspectRatioLabel: studioT('single.labels.aspectRatio'),
+      outputQualityLabel: studioT('single.labels.outputQuality'),
+      durationLabel: studioT('single.labels.duration'),
+      characterOrientationLabel: studioT(
+        'canvas.composer.characterOrientation'
+      ),
+      backgroundSourceLabel: studioT('canvas.composer.backgroundSource'),
+      languageLabel: studioT('canvas.composer.language'),
+      uploadImageLabel: studioT('actions.uploadImage'),
+      uploadVideoLabel: studioT('actions.uploadVideo'),
+      fromCanvasLabel: studioT('canvas.composer.fromCanvas'),
+      currentReferencesLabel: studioT('canvas.composer.currentReferences'),
+      noCanvasReferencesLabel: studioT('canvas.composer.noCanvasReferences'),
+      removeReferenceLabel: studioT('canvas.composer.removeReference'),
+      generateLabel: studioT('canvas.composer.generate'),
+      regenerateLabel: studioT('canvas.composer.regenerate'),
+      generatingLabel: studioT('canvas.composer.generating'),
+      closeComposerLabel: studioT('canvas.composer.close'),
+      defaultSetupLabel: studioT('canvas.composer.defaultSetup'),
+      modeOptionLabel: studioT('canvas.composer.mode'),
+      variantOptionLabel: studioT('canvas.composer.variant'),
+      qualityOptionLabel: studioT('canvas.composer.quality'),
+      tokenQualityLabel: studioT('canvas.composer.tokens.quality'),
+      tokenFastLabel: studioT('canvas.composer.tokens.fast'),
+      tokenLiteLabel: studioT('canvas.composer.tokens.lite'),
+      tokenLowLabel: studioT('canvas.composer.tokens.low'),
+      tokenMediumLabel: studioT('canvas.composer.tokens.medium'),
+      tokenStandardLabel: studioT('canvas.composer.tokens.standard'),
+      tokenHighLabel: studioT('canvas.composer.tokens.high'),
+      tokenProLabel: studioT('canvas.composer.tokens.pro'),
+      tokenAdaptiveLabel: studioT('canvas.composer.tokens.adaptive'),
+      tokenAutoLabel: studioT('canvas.composer.tokens.auto'),
+      tokenLandscapeLabel: studioT('canvas.composer.tokens.landscape'),
+      tokenPortraitLabel: studioT('canvas.composer.tokens.portrait'),
+      tokenChineseLabel: studioT('canvas.composer.tokens.chinese'),
+      tokenEnglishLabel: studioT('canvas.composer.tokens.english'),
+      tokenImageOrientationLabel: studioT(
+        'canvas.composer.tokens.imageOrientation'
+      ),
+      tokenVideoOrientationLabel: studioT(
+        'canvas.composer.tokens.videoOrientation'
+      ),
+      tokenInputImageLabel: studioT('canvas.composer.tokens.inputImage'),
+      tokenInputVideoLabel: studioT('canvas.composer.tokens.inputVideo'),
+      queuedStatusLabel: studioT('canvas.composer.status.queued'),
+      generatingStatusLabel: studioT('canvas.composer.status.generating'),
+      readyStatusLabel: studioT('canvas.composer.status.ready'),
+      failedStatusLabel: studioT('canvas.composer.status.failed'),
+    }),
+    [studioT]
+  );
+}

--- a/src/components/home/workspace-page.tsx
+++ b/src/components/home/workspace-page.tsx
@@ -26,7 +26,7 @@ import { m } from '@/paraglide/messages.js';
 type WorkspaceProject = {
   id: string;
   name: string;
-  lastWorkspaceMode?: 'studio' | 'canvas';
+  lastWorkspaceMode?: 'studio' | 'canvas' | 'assets';
   activityAt: string;
   activityLabel: string;
   coverImageUrl?: string | null;

--- a/src/components/marketing/beatapi-product-home.tsx
+++ b/src/components/marketing/beatapi-product-home.tsx
@@ -1,9 +1,7 @@
 import {
   ArrowRight,
   ArrowUp,
-  Film,
   FolderClock,
-  ImagePlus,
   PanelsTopLeft,
   Workflow,
 } from 'lucide-react';
@@ -39,12 +37,7 @@ function getCopy(locale: string) {
       { locale: messageLocale }
     ),
     open: m['product.home.openWorkspace']({}, { locale: messageLocale }),
-    createInStudio: m['product.home.createInStudio'](
-      {},
-      { locale: messageLocale }
-    ),
-    mediaImage: m['product.home.mediaImage']({}, { locale: messageLocale }),
-    mediaVideo: m['product.home.mediaVideo']({}, { locale: messageLocale }),
+    create: m['product.shell.create']({}, { locale: messageLocale }),
   };
 }
 
@@ -79,7 +72,7 @@ function WorkspaceCard({
         <h3 className="beat-product-display mt-6 text-[17px] font-semibold tracking-[-0.02em] text-[var(--beat-text-1)]">
           {title}
         </h3>
-        <p className="mt-2 max-w-[330px] text-[13px] leading-[1.65] text-[var(--beat-text-2)]">
+        <p className="mt-2 truncate whitespace-nowrap text-[13px] leading-[1.65] text-[var(--beat-text-2)]">
           {description}
         </p>
         <span className="mt-auto inline-flex items-center gap-2 pt-6 text-[12.5px] font-medium text-white/65 transition-colors group-hover:text-white">
@@ -93,10 +86,6 @@ function WorkspaceCard({
 
 function PromptComposer({ copy }: { copy: HomeCopy }) {
   const [prompt, setPrompt] = useState('');
-  const mediaActions = [
-    { label: copy.mediaImage, icon: ImagePlus },
-    { label: copy.mediaVideo, icon: Film },
-  ] as const;
 
   return (
     <form
@@ -112,23 +101,10 @@ function PromptComposer({ copy }: { copy: HomeCopy }) {
         aria-label={copy.prompt}
         className="min-h-16 w-full resize-none border-0 bg-transparent text-[15px] leading-6 text-white outline-none placeholder:text-[var(--beat-text-3)] sm:text-base"
       />
-      <div className="mt-auto flex items-end justify-between gap-3">
-        <div className="flex flex-wrap gap-1.5">
-          {mediaActions.map(({ label, icon: Icon }) => (
-            <button
-              key={label}
-              type="button"
-              onClick={() => setPrompt((value) => value || `${label}: `)}
-              className="inline-flex h-9 items-center gap-2 rounded-full border border-white/[0.09] bg-white/[0.035] px-3 text-xs font-medium text-[var(--beat-text-2)] transition hover:border-white/[0.18] hover:bg-white/[0.06] hover:text-white"
-            >
-              <Icon className="size-3.5" />
-              {label}
-            </button>
-          ))}
-        </div>
+      <div className="mt-auto flex items-end justify-end">
         <button
           type="submit"
-          aria-label={copy.createInStudio}
+          aria-label={copy.create}
           className="grid size-10 shrink-0 place-items-center rounded-full bg-[var(--beat-accent)] text-[var(--beat-accent-ink)] shadow-[0_8px_24px_rgba(255,122,51,0.3)] transition hover:scale-[1.04] hover:bg-[#ff8a4d]"
         >
           <ArrowUp className="size-4" />

--- a/src/components/marketing/beatapi-product-shell.test.ts
+++ b/src/components/marketing/beatapi-product-shell.test.ts
@@ -9,8 +9,7 @@ const source = readFileSync(
 
 test('product shell keeps workspace navigation with pricing and hides SaaS auth', () => {
   assert.match(source, /label: copy\.home, href: '\/'/);
-  assert.match(source, /href: '\/studio'/);
-  assert.match(source, /href: '\/canvas'/);
+  assert.match(source, /label: copy\.create, href: '\/studio'/);
   assert.match(source, /href: '\/pricing'/);
   assert.match(source, /href: '\/projects'/);
   assert.doesNotMatch(source, /href="\/sign-in"/);

--- a/src/components/marketing/beatapi-product-shell.tsx
+++ b/src/components/marketing/beatapi-product-shell.tsx
@@ -24,8 +24,7 @@ function getShellCopy(locale: string) {
   const messageLocale = normalizeLocale(locale);
   return {
     home: m['product.shell.home']({}, { locale: messageLocale }),
-    studio: m['product.shell.studio']({}, { locale: messageLocale }),
-    canvas: m['product.shell.canvas']({}, { locale: messageLocale }),
+    create: m['product.shell.create']({}, { locale: messageLocale }),
     pricing: m['product.shell.pricing']({}, { locale: messageLocale }),
     projects: m['product.shell.projects']({}, { locale: messageLocale }),
     openNavigation: m['product.shell.openNavigation'](
@@ -40,8 +39,8 @@ function getShellCopy(locale: string) {
       {},
       { locale: messageLocale }
     ),
-    english: m['product.shell.english']({}, { locale: messageLocale }),
-    chinese: m['product.shell.chinese']({}, { locale: messageLocale }),
+    english: m['product.shell.english']({}, { locale: 'en' }),
+    chinese: m['product.shell.chinese']({}, { locale: 'zh' }),
     terms: m['product.shell.terms']({}, { locale: messageLocale }),
     privacy: m['product.shell.privacy']({}, { locale: messageLocale }),
   };
@@ -52,8 +51,7 @@ type ShellCopy = ReturnType<typeof getShellCopy>;
 function getNavItems(copy: ShellCopy) {
   return [
     { label: copy.home, href: '/' },
-    { label: copy.studio, href: '/studio' },
-    { label: copy.canvas, href: '/canvas' },
+    { label: copy.create, href: '/studio' },
     { label: copy.pricing, href: '/pricing' },
     { label: copy.projects, href: '/projects' },
   ] as const;
@@ -116,8 +114,8 @@ function LocaleMenu({ locale, copy }: { locale: ProductLocale; copy: ShellCopy }
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const options = [
-    { code: 'en' as const, short: 'EN', label: copy.english },
-    { code: 'zh' as const, short: 'ZH', label: copy.chinese },
+    { code: 'en' as const, label: copy.english },
+    { code: 'zh' as const, label: copy.chinese },
   ];
 
   useEffect(() => {
@@ -143,32 +141,31 @@ function LocaleMenu({ locale, copy }: { locale: ProductLocale; copy: ShellCopy }
         aria-label={copy.switchLanguage}
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
-        className="inline-flex h-10 items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.035] px-3 text-[12px] font-semibold text-white/70 transition hover:border-white/20 hover:bg-white/[0.07] hover:text-white"
+        className="inline-flex h-8 items-center gap-1 rounded-full px-2 text-[13px] font-medium text-white/45 transition hover:bg-white/[0.06] hover:text-white"
       >
-        <Globe2 className="size-3.5 text-white/40" />
+        <Globe2 className="size-3.5" />
         {locale.toUpperCase()}
         <ChevronDown
-          className={`size-3 text-white/35 transition-transform ${open ? 'rotate-180' : ''}`}
+          className={`size-3 opacity-70 transition-transform ${open ? 'rotate-180' : ''}`}
         />
       </button>
 
       {open ? (
-        <div className="absolute right-0 top-full z-50 mt-2 min-w-[150px] overflow-hidden rounded-[14px] border border-white/10 bg-[#151517] p-1.5 shadow-2xl">
+        <div className="absolute right-0 top-full z-50 mt-2 min-w-[132px] overflow-hidden rounded-[12px] border border-white/[0.08] bg-[#151517] p-1 shadow-[0_16px_40px_rgba(0,0,0,0.45)]">
           {options.map((option) => (
             <button
               key={option.code}
               type="button"
               onClick={() => switchLanguage(option.code)}
-              className="flex w-full items-center gap-3 rounded-[10px] px-3 py-2.5 text-left text-[12px] text-[#b8b8bd] transition hover:bg-white/[0.06] hover:text-white"
+              className={`flex w-full items-center justify-between rounded-[8px] px-2.5 py-2 text-left text-[13px] transition hover:bg-white/[0.06] ${
+                option.code === locale
+                  ? 'text-white'
+                  : 'text-[var(--beat-text-2)] hover:text-white'
+              }`}
             >
-              <span className="w-6 text-[10px] font-bold text-[#6f6f76]">
-                {option.short}
-              </span>
-              <span className={option.code === locale ? 'font-semibold text-white' : ''}>
-                {option.label}
-              </span>
+              {option.label}
               {option.code === locale ? (
-                <Check className="ml-auto size-3.5 text-[var(--beat-accent)]" />
+                <Check className="size-3.5 text-[var(--beat-accent)]" />
               ) : null}
             </button>
           ))}

--- a/src/components/studio/beat-studio-workspace.test.ts
+++ b/src/components/studio/beat-studio-workspace.test.ts
@@ -6,6 +6,14 @@ const studioSource = readFileSync(
   new URL('./beat-studio-workspace.tsx', import.meta.url),
   'utf8'
 );
+const composerSource = readFileSync(
+  new URL('./studio-composer.tsx', import.meta.url),
+  'utf8'
+);
+const feedSource = readFileSync(
+  new URL('./studio-generation-feed.tsx', import.meta.url),
+  'utf8'
+);
 const startHereSource = readFileSync(
   new URL('./studio-start-here.tsx', import.meta.url),
   'utf8'
@@ -17,38 +25,29 @@ test('studio uses the shared black creative surface without a persistent media s
   assert.doesNotMatch(studioSource, /w-14 shrink-0 flex-col/);
 });
 
-test('studio mirrors the BeatAPI start state and composer rhythm', () => {
-  const composerIndex = studioSource.indexOf('max-w-[1138px]');
-  const mediaSelectIndex = studioSource.indexOf(
-    'ariaLabel="Media type"',
-    composerIndex
-  );
-
-  assert.ok(composerIndex >= 0);
-  assert.ok(mediaSelectIndex > composerIndex);
+test('studio keeps the original wide composer and a project generation feed', () => {
+  assert.match(studioSource, /StudioComposer/);
+  assert.match(studioSource, /StudioGenerationFeed/);
   assert.match(studioSource, /StudioStartHere/);
+  assert.match(composerSource, /max-w-\[1138px\]/);
+  assert.match(composerSource, /ariaLabel="Media type"/);
+  assert.match(composerSource, /WorkspaceSelect/);
+  assert.match(composerSource, /BeatCanvasComposerParameterPicker/);
+  assert.match(composerSource, /truncatePromptToMaxChars/);
+  assert.match(composerSource, /labels\.regenerateLabel/);
+  assert.match(feedSource, /max-w-\[1138px\]/);
+  assert.match(feedSource, /formatStudioHistoryDateTime/);
+  assert.match(feedSource, /h-\[240px\]/);
+  assert.match(feedSource, /object-contain/);
+  assert.doesNotMatch(feedSource, /item\.prompt/);
+  assert.match(studioSource, /justify-end/);
   assert.match(startHereSource, /Create Here/);
-  assert.match(
-    startHereSource,
-    /Imagine the scene\. Shape the mood\. Bring it to life\./
-  );
-  assert.match(startHereSource, /pointer-events-auto/);
-  assert.match(startHereSource, /create-thumb-forest\.webp/);
-  assert.match(startHereSource, /aria-pressed/);
-  assert.match(startHereSource, /setSelectedSrc/);
-  assert.doesNotMatch(startHereSource, /onSelect/);
-  assert.doesNotMatch(studioSource, /selectStarterIdea/);
-  assert.match(studioSource, /data-beatapi-composer/);
-  assert.match(studioSource, /WorkspaceSelect/);
+  assert.match(studioSource, /fetchProjectGenerations/);
 });
 
 test('studio model selector follows the selected model name width', () => {
   assert.match(
-    studioSource,
+    composerSource,
     /ariaLabel="Model"[\s\S]*?triggerClassName="w-fit max-w-full"/
-  );
-  assert.doesNotMatch(
-    studioSource,
-    /ariaLabel="Model"[\s\S]*?triggerClassName="w-\[224px\]"/
   );
 });

--- a/src/components/studio/beat-studio-workspace.tsx
+++ b/src/components/studio/beat-studio-workspace.tsx
@@ -1,33 +1,32 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import {
-  ArrowUp,
-  Film,
-  ImageIcon,
-  ImagePlus,
-  Loader2,
-  Sparkles,
-} from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { resolveOutputMedia } from '@/core/effects/output-media';
+import { StudioComposer } from '@/components/studio/studio-composer';
+import { StudioGenerationFeed } from '@/components/studio/studio-generation-feed';
+import { StudioStartHere } from '@/components/studio/studio-start-here';
+import type { CanvasCardMediaType } from '@/core/beatcanvas/canvas-types';
 import { resolveWmTaskId } from '@/core/effects/client-api';
-import { getModelIconPathByModelId } from '@/core/workspace-lib/model-icons';
-import { WorkspaceSelect } from '@/components/app/workspace-select';
+import { resolveOutputMedia } from '@/core/effects/output-media';
+import { generationValidationConstraints } from '@/core/effects/validation';
 import {
-  composerCardClassName,
-  composerGenerateButtonClassName,
-} from '@/components/app/composer-styles';
+  findWorkspaceModelOption,
+  getDefaultSelectableWorkspaceModel,
+} from '@/core/effects/workspace-models';
+import {
+  applyStudioDraftModel,
+  createStudioDraftCard,
+} from '@/core/studio/studio-draft';
 import {
   buildStudioEffectInput,
   getStudioModels,
   type StudioMedia,
 } from '@/core/studio/studio-runtime';
-import { apiJsonGet, apiJsonPost } from '@/lib/api-client';
+import { fetchProjectGenerations } from '@/core/workspace-lib/app/workspace-client-api';
 import { invalidateWorkspaceAfterGeneration } from '@/core/workspace-lib/app/workspace-query-invalidation';
-import { StudioStartHere } from '@/components/studio/studio-start-here';
-import { cn } from '@/lib/utils';
+import { projectGenerationsKeys } from '@/core/workspace-lib/app/workspace-query-keys';
+import { apiJsonGet, apiJsonPost } from '@/lib/api-client';
 
 type GenerationResponse = {
   status?: 'pending' | 'processing' | 'succeeded' | 'failed';
@@ -76,42 +75,67 @@ export function BeatStudioWorkspace({
   const queryClient = useQueryClient();
   const initialMedia: StudioMedia =
     initialTarget === 'video' ? 'video' : 'image';
-  const [media, setMedia] = useState<StudioMedia>(initialMedia);
-  const [prompt, setPrompt] = useState(initialPrompt || '');
-  const [aspectRatio, setAspectRatio] = useState(
-    initialMedia === 'video' ? '16:9' : '1:1'
-  );
-  const [modelId, setModelId] = useState(initialModelId || '');
-  const [resultUrl, setResultUrl] = useState<string | null>(null);
+  const imageModels = useMemo(() => getStudioModels('image'), []);
+  const videoModels = useMemo(() => getStudioModels('video'), []);
+  const [draft, setDraft] = useState(() => {
+    const models = initialMedia === 'video' ? videoModels : imageModels;
+    const model =
+      findWorkspaceModelOption(models, initialModelId) ??
+      getDefaultSelectableWorkspaceModel(
+        initialMedia === 'video' ? 'ai-video' : 'ai-image'
+      );
+    return createStudioDraftCard({
+      type: initialMedia,
+      model,
+      prompt: initialPrompt || '',
+    });
+  });
   const [error, setError] = useState('');
-  const models = useMemo(() => getStudioModels(media), [media]);
+  const models = draft.type === 'video' ? videoModels : imageModels;
   const selectedModel =
-    models.find((model) => model.id === modelId) ?? models[0] ?? null;
+    findWorkspaceModelOption(models, draft.modelId) ?? models[0] ?? null;
+
+  const generationsQuery = useQuery({
+    queryKey: projectGenerationsKeys.list(projectId),
+    queryFn: () => fetchProjectGenerations(projectId),
+    refetchInterval: (query) =>
+      query.state.data?.items.some(
+        (item) => item.status === 'pending' || item.status === 'processing'
+      )
+        ? 2500
+        : false,
+  });
+  const feedItems = (generationsQuery.data?.items ?? []).filter(
+    (item) => item.status !== 'failed'
+  );
 
   useEffect(() => {
-    if (!selectedModel) return;
-    if (selectedModel.id !== modelId) setModelId(selectedModel.id);
-    const ratios = selectedModel.supportedAspectRatios || [];
-    if (ratios.length && !ratios.includes(aspectRatio as never)) {
-      setAspectRatio(selectedModel.defaultAspectRatio || ratios[0]);
-    }
-  }, [aspectRatio, modelId, selectedModel]);
+    if (!selectedModel || selectedModel.id === draft.modelId) return;
+    setDraft((current) =>
+      applyStudioDraftModel({ draft: current, model: selectedModel })
+    );
+  }, [draft.modelId, selectedModel]);
 
   const generation = useMutation({
     mutationFn: async () => {
       if (!selectedModel) {
         throw new Error('No model is available for this media type.');
       }
-      if (!prompt.trim()) {
+      if (!draft.prompt.trim()) {
         throw new Error('Describe what you want to create first.');
       }
       const payload = {
         effectId: selectedModel.effectId,
         input: buildStudioEffectInput({
-          media,
+          media: draft.type,
           model: selectedModel,
-          prompt,
-          aspectRatio,
+          prompt: draft.prompt,
+          aspectRatio: draft.aspectRatio,
+          duration: draft.duration,
+          outputQuality: draft.outputQuality,
+          mode: draft.mode,
+          quality: draft.quality,
+          language: draft.language,
         }),
         projectId,
       };
@@ -133,26 +157,25 @@ export function BeatStudioWorkspace({
       if (created.status === 'failed') {
         throw new Error(created.error || 'Generation failed');
       }
-      let output = created.output;
+      await invalidateWorkspaceAfterGeneration(queryClient);
       const wmTaskId = resolveWmTaskId(created);
       if (wmTaskId && created.status !== 'succeeded') {
-        output = await waitForGeneration({
+        await waitForGeneration({
           wmTaskId,
           effectId: selectedModel.effectId,
         });
-      }
-      const mediaOutput = resolveOutputMedia(output);
-      if (!mediaOutput.resultUrl) {
+      } else if (!resolveOutputMedia(created.output).resultUrl) {
         throw new Error('Generation completed without a media URL.');
       }
-      return mediaOutput.resultUrl;
     },
-    onSuccess: (url) => {
-      setResultUrl(url);
+    onSuccess: () => {
       setError('');
       void invalidateWorkspaceAfterGeneration(queryClient);
     },
-    onError: (generationError: Error) => setError(generationError.message),
+    onError: (generationError: Error) => {
+      setError(generationError.message);
+      void invalidateWorkspaceAfterGeneration(queryClient);
+    },
   });
 
   return (
@@ -160,152 +183,56 @@ export function BeatStudioWorkspace({
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_112%,rgba(255,122,51,0.12),transparent_34%),linear-gradient(180deg,#08090a_0%,#0b0b0d_48%,#08090a_100%)]" />
       <div className="pointer-events-none absolute inset-x-[8%] top-0 h-[62%] opacity-25 [background-image:radial-gradient(rgba(255,255,255,0.16)_0.75px,transparent_0.75px)] [background-size:18px_18px] [mask-image:linear-gradient(to_bottom,black,transparent)]" />
 
-      <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-4 pb-[220px] pt-8 sm:px-6 sm:pb-[210px] md:pb-[190px]">
-        {resultUrl ? (
-          <div className="w-full max-w-[780px] overflow-hidden rounded-[var(--beat-radius)] border border-white/[0.09] bg-black shadow-[0_38px_120px_rgba(0,0,0,0.58)]">
-            {media === 'video' ? (
-              <video
-                src={resultUrl}
-                controls
-                autoPlay
-                className="max-h-[55vh] w-full object-contain"
-              />
-            ) : (
-              <img
-                src={resultUrl}
-                alt="Generated result"
-                className="max-h-[55vh] w-full object-contain"
-              />
-            )}
+      <div className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-[220px] pt-8 sm:px-6 sm:pb-[210px]">
+        {feedItems.length > 0 ? (
+          <div className="flex min-h-full w-full flex-col justify-end">
+            <StudioGenerationFeed items={feedItems} />
           </div>
         ) : (
-          <StudioStartHere />
+          <div className="flex flex-1 items-center justify-center">
+            <StudioStartHere />
+          </div>
         )}
       </div>
 
-      <div className="absolute inset-x-0 bottom-0 z-20 bg-gradient-to-t from-[#09090a] via-[#09090a]/96 to-transparent px-3 pb-3 pt-12 sm:px-6 sm:pb-5 sm:pt-14">
-        <div
-          className={cn(
-            'mx-auto w-full max-w-[1138px] overflow-hidden p-2.5 sm:p-3.5',
-            composerCardClassName
-          )}
-          data-beatapi-composer=""
-        >
-          <div className="relative">
-            <button
-              type="button"
-              aria-label="Add a reference image"
-              title="Reference upload coming next"
-              className="absolute left-0 top-0 z-10 flex size-9 rotate-[-5deg] items-center justify-center rounded-[10px] border border-dashed border-white/[0.13] bg-white/[0.03] text-[var(--beat-text-2)] shadow-[0_8px_20px_rgba(0,0,0,0.24)] transition hover:border-white/25 hover:bg-white/[0.06]"
-            >
-              <ImagePlus className="size-3.5" />
-            </button>
-            <textarea
-              value={prompt}
-              onChange={(event) => setPrompt(event.target.value)}
-              placeholder="Describe the subject, motion, camera, lighting, and atmosphere you want to create."
-              className="h-[80px] min-h-[80px] w-full resize-none bg-transparent py-2 pl-[52px] pr-3 text-[14px] leading-6 text-[var(--beat-text-1)] outline-none placeholder:text-white/35 sm:h-[92px] sm:min-h-[92px] sm:pl-[56px] sm:pr-16 sm:text-[15px]"
-            />
-          </div>
+      <StudioComposer
+        draft={draft}
+        imageModels={imageModels}
+        videoModels={videoModels}
+        isBusy={generation.isPending}
+        promptCharacterLimit={generationValidationConstraints.maxPromptChars}
+        takeCount={feedItems.length}
+        onDraftChange={(next) => {
+          if (next.type !== draft.type || next.modelId !== draft.modelId) {
+            const nextModels =
+              next.type === 'video' ? videoModels : imageModels;
+            const nextModel =
+              findWorkspaceModelOption(nextModels, next.modelId) ??
+              nextModels[0] ??
+              null;
+            if (nextModel) {
+              setDraft(
+                applyStudioDraftModel({
+                  draft: { ...next, type: next.type as CanvasCardMediaType },
+                  model: nextModel,
+                })
+              );
+              return;
+            }
+          }
+          setDraft(next);
+        }}
+        onGenerate={() => {
+          setError('');
+          generation.mutate();
+        }}
+      />
 
-          <div className="mt-1.5 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-            <div className="grid min-w-0 flex-1 grid-cols-2 gap-1.5 sm:flex sm:flex-wrap sm:items-center">
-              <div className="min-w-0">
-                <WorkspaceSelect
-                  ariaLabel="Media type"
-                  triggerClassName="min-w-[96px]"
-                  value={media}
-                  options={[
-                    {
-                      value: 'image',
-                      label: 'Image',
-                      leading: (
-                        <ImageIcon className="size-3.5 shrink-0 text-[var(--beat-text-2)]" />
-                      ),
-                    },
-                    {
-                      value: 'video',
-                      label: 'Video',
-                      leading: (
-                        <Film className="size-3.5 shrink-0 text-[var(--beat-text-2)]" />
-                      ),
-                    },
-                  ]}
-                  onChange={(next) => setMedia(next as StudioMedia)}
-                />
-              </div>
-
-              <div className="min-w-0">
-                <WorkspaceSelect
-                  ariaLabel="Model"
-                  triggerClassName="w-fit max-w-full"
-                  value={selectedModel?.id || ''}
-                  options={models.map((model) => ({
-                    value: model.id,
-                    label: model.name,
-                    leading: (
-                      <span className="grid size-4 shrink-0 place-items-center rounded-[4px] bg-white/90 ring-1 ring-black/10">
-                        <img
-                          src={getModelIconPathByModelId(model.id) || '/logo.png'}
-                          alt=""
-                          className="size-3 rounded-[2px]"
-                        />
-                      </span>
-                    ),
-                  }))}
-                  onChange={setModelId}
-                  leadingIcon={<Sparkles className="size-3.5 shrink-0 text-[var(--beat-text-2)]" />}
-                />
-              </div>
-
-              <div className="min-w-0">
-                <WorkspaceSelect
-                  ariaLabel="Aspect ratio"
-                  triggerClassName="min-w-[88px]"
-                  value={aspectRatio}
-                  options={(
-                    selectedModel?.supportedAspectRatios || [
-                      media === 'video' ? '16:9' : '1:1',
-                    ]
-                  ).map((ratio) => ({ value: ratio, label: ratio }))}
-                  onChange={setAspectRatio}
-                  leadingIcon={
-                    <span className="size-3.5 shrink-0 rounded-[3px] border border-white/40" />
-                  }
-                />
-              </div>
-            </div>
-
-            <div className="flex shrink-0 items-center justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => {
-                  setError('');
-                  generation.mutate();
-                }}
-                disabled={
-                  generation.isPending || !prompt.trim() || !selectedModel
-                }
-                className={cn(
-                  composerGenerateButtonClassName,
-                  'active:translate-y-px'
-                )}
-                aria-label="Generate"
-              >
-                {generation.isPending ? (
-                  <Loader2 className="size-3.5 animate-spin" />
-                ) : (
-                  <ArrowUp className="size-3.5" />
-                )}
-              </button>
-            </div>
-          </div>
-
-          {error ? (
-            <p className="px-1 pt-3 text-sm text-[var(--beatcanvas-error)]">{error}</p>
-          ) : null}
-        </div>
-      </div>
+      {error ? (
+        <p className="pointer-events-none absolute inset-x-0 bottom-[88px] z-30 px-6 text-center text-sm text-[var(--beatcanvas-error)]">
+          {error}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/src/components/studio/studio-composer.tsx
+++ b/src/components/studio/studio-composer.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import {
+  ArrowUp,
+  Film,
+  ImageIcon,
+  ImagePlus,
+  Loader2,
+  RotateCw,
+  Sparkles,
+} from 'lucide-react';
+import { useRef, useState } from 'react';
+
+import {
+  composerCardClassName,
+  composerGenerateButtonClassName,
+} from '@/components/app/composer-styles';
+import { WorkspaceSelect } from '@/components/app/workspace-select';
+import { BeatCanvasComposerParameterPicker } from '@/components/beatcanvas/beatcanvas-composer-parameter-picker';
+import { normalizeComposerToken } from '@/components/beatcanvas/beatcanvas-composer-utils';
+import { useCanvasComposerLabels } from '@/components/beatcanvas/use-canvas-composer-labels';
+import type { CanvasGenerationCard } from '@/core/beatcanvas/canvas-types';
+import {
+  countPromptCharacters,
+  truncatePromptToMaxChars,
+} from '@/core/effects/validation';
+import {
+  findWorkspaceModelOption,
+  type WorkspaceModelOption,
+} from '@/core/effects/workspace-models';
+import { getModelIconPathByModelId } from '@/core/workspace-lib/model-icons';
+import { cn } from '@/lib/utils';
+
+export function StudioComposer({
+  draft,
+  imageModels,
+  videoModels,
+  isBusy,
+  promptCharacterLimit,
+  takeCount = 0,
+  onDraftChange,
+  onGenerate,
+}: {
+  draft: CanvasGenerationCard;
+  imageModels: WorkspaceModelOption[];
+  videoModels: WorkspaceModelOption[];
+  isBusy: boolean;
+  promptCharacterLimit: number;
+  takeCount?: number;
+  onDraftChange: (next: CanvasGenerationCard) => void;
+  onGenerate: () => void;
+}) {
+  const labels = useCanvasComposerLabels();
+  const parameterPickerRef = useRef<HTMLDivElement | null>(null);
+  const [isParameterOpen, setIsParameterOpen] = useState(false);
+  const models = draft.type === 'video' ? videoModels : imageModels;
+  const selectedModel =
+    findWorkspaceModelOption(models, draft.modelId) ?? models[0] ?? null;
+  const selectedModeOptions = selectedModel?.modeOptions ?? [];
+  const selectedVariantOptions = selectedModel?.variantOptions ?? [];
+  const selectedQualityOptions = selectedModel?.qualityOptions ?? [];
+  const selectedDurationOptions =
+    draft.type === 'video' ? (selectedModel?.supportedDurations ?? []) : [];
+  const selectedLanguageOptions = selectedModel?.supportedLanguages ?? [];
+  const selectedAspectRatioOptions = selectedModel?.supportedAspectRatios ?? [];
+  const selectedOutputQualities = selectedModel?.supportedOutputQualities ?? [];
+  const selectedCharacterOrientationOptions =
+    selectedModel?.characterOrientationOptions ?? [];
+  const selectedBackgroundSourceOptions =
+    selectedModel?.backgroundSourceOptions ?? [];
+  const visibleParameterSummaryTokens = [
+    ...(selectedOutputQualities.length > 0
+      ? [draft.outputQuality.toUpperCase()]
+      : []),
+    ...(selectedAspectRatioOptions.length > 0
+      ? [normalizeComposerToken(draft.aspectRatio, labels)]
+      : []),
+    ...(selectedDurationOptions.length > 0 ? [draft.duration] : []),
+    ...(selectedModeOptions.length > 1
+      ? [normalizeComposerToken(draft.mode, labels)]
+      : []),
+    ...(selectedVariantOptions.length > 1
+      ? [normalizeComposerToken(draft.variant, labels)]
+      : []),
+    ...(selectedQualityOptions.length > 1
+      ? [normalizeComposerToken(draft.quality, labels)]
+      : []),
+  ];
+  const promptCharacterCount = countPromptCharacters(draft.prompt);
+  const hasExistingTakes = takeCount > 0;
+  const primaryButtonLabel = isBusy
+    ? labels.generatingLabel
+    : hasExistingTakes
+      ? labels.regenerateLabel
+      : labels.generateLabel;
+
+  return (
+    <div className="absolute inset-x-0 bottom-0 z-20 bg-gradient-to-t from-[#09090a] via-[#09090a]/96 to-transparent px-3 pb-3 pt-12 sm:px-6 sm:pb-5 sm:pt-14">
+      <div
+        className={cn(
+          'mx-auto w-full max-w-[1138px] p-2.5 sm:p-3.5',
+          composerCardClassName
+        )}
+        data-beatapi-composer=""
+      >
+        <div className="relative">
+          <button
+            type="button"
+            aria-label={labels.uploadImageLabel}
+            title="Reference upload coming next"
+            className="absolute left-0 top-0 z-10 flex size-9 rotate-[-5deg] items-center justify-center rounded-[10px] border border-dashed border-white/[0.13] bg-white/[0.03] text-[var(--beat-text-2)] shadow-[0_8px_20px_rgba(0,0,0,0.24)] transition hover:border-white/25 hover:bg-white/[0.06]"
+          >
+            <ImagePlus className="size-3.5" />
+          </button>
+          <textarea
+            value={draft.prompt}
+            onChange={(event) =>
+              onDraftChange({
+                ...draft,
+                prompt: truncatePromptToMaxChars(
+                  event.target.value,
+                  promptCharacterLimit
+                ),
+              })
+            }
+            placeholder={
+              draft.type === 'video'
+                ? labels.videoPromptPlaceholder
+                : labels.imagePromptPlaceholder
+            }
+            disabled={isBusy}
+            className="h-[80px] min-h-[80px] w-full resize-none bg-transparent py-2 pl-[52px] pr-3 text-[14px] leading-6 text-[var(--beat-text-1)] outline-none placeholder:text-white/35 sm:h-[92px] sm:min-h-[92px] sm:pl-[56px] sm:pr-16 sm:text-[15px]"
+          />
+        </div>
+
+        <div className="mt-1.5 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+            <WorkspaceSelect
+              ariaLabel="Media type"
+              triggerClassName="min-w-[96px]"
+              value={draft.type}
+              options={[
+                {
+                  value: 'image',
+                  label: labels.imageModeLabel,
+                  leading: (
+                    <ImageIcon className="size-3.5 shrink-0 text-[var(--beat-text-2)]" />
+                  ),
+                },
+                {
+                  value: 'video',
+                  label: labels.videoModeLabel,
+                  leading: (
+                    <Film className="size-3.5 shrink-0 text-[var(--beat-text-2)]" />
+                  ),
+                },
+              ]}
+              onChange={(type) =>
+                onDraftChange({
+                  ...draft,
+                  type: type === 'video' ? 'video' : 'image',
+                })
+              }
+            />
+
+            <WorkspaceSelect
+              ariaLabel="Model"
+              triggerClassName="w-fit max-w-full"
+              value={selectedModel?.id || ''}
+              options={models.map((model) => ({
+                value: model.id,
+                label: model.name,
+                leading: (
+                  <span className="grid size-4 shrink-0 place-items-center rounded-[4px] bg-white/90 ring-1 ring-black/10">
+                    <img
+                      src={getModelIconPathByModelId(model.id) || '/logo.png'}
+                      alt=""
+                      className="size-3 rounded-[2px]"
+                    />
+                  </span>
+                ),
+              }))}
+              onChange={(modelId) => onDraftChange({ ...draft, modelId })}
+              leadingIcon={
+                <Sparkles className="size-3.5 shrink-0 text-[var(--beat-text-2)]" />
+              }
+            />
+
+            {visibleParameterSummaryTokens.length > 0 ? (
+              <BeatCanvasComposerParameterPicker
+                activeDraftCard={draft}
+                containerRef={parameterPickerRef}
+                isDraftBusy={isBusy}
+                isOpen={isParameterOpen}
+                labels={labels}
+                onDraftAspectRatioChange={(_draftId, aspectRatio) =>
+                  onDraftChange({ ...draft, aspectRatio })
+                }
+                onDraftBackgroundSourceChange={(_draftId, backgroundSource) =>
+                  onDraftChange({ ...draft, backgroundSource })
+                }
+                onDraftCharacterOrientationChange={(
+                  _draftId,
+                  characterOrientation
+                ) => onDraftChange({ ...draft, characterOrientation })}
+                onDraftDurationChange={(_draftId, duration) =>
+                  onDraftChange({ ...draft, duration })
+                }
+                onDraftLanguageChange={(_draftId, language) =>
+                  onDraftChange({ ...draft, language })
+                }
+                onDraftModeChange={(_draftId, mode) =>
+                  onDraftChange({ ...draft, mode })
+                }
+                onDraftOutputQualityChange={(_draftId, outputQuality) =>
+                  onDraftChange({ ...draft, outputQuality })
+                }
+                onDraftQualityChange={(_draftId, quality) =>
+                  onDraftChange({ ...draft, quality })
+                }
+                onDraftVariantChange={(_draftId, variant) =>
+                  onDraftChange({ ...draft, variant })
+                }
+                onOpenChange={setIsParameterOpen}
+                parameterSummaryLabel={labels.parameterLabel}
+                selectedAspectRatioOptions={selectedAspectRatioOptions}
+                selectedBackgroundSourceOptions={
+                  selectedBackgroundSourceOptions
+                }
+                selectedCharacterOrientationOptions={
+                  selectedCharacterOrientationOptions
+                }
+                selectedDurationOptions={selectedDurationOptions}
+                selectedLanguageOptions={selectedLanguageOptions}
+                selectedModeOptions={selectedModeOptions}
+                selectedOutputQualities={selectedOutputQualities}
+                selectedQualityOptions={selectedQualityOptions}
+                selectedVariantOptions={selectedVariantOptions}
+                visibleParameterSummaryTokens={visibleParameterSummaryTokens}
+              />
+            ) : null}
+          </div>
+
+          <div className="flex shrink-0 items-center justify-end gap-2">
+            <span
+              className={cn(
+                'text-[10px] font-medium tabular-nums',
+                promptCharacterCount >= promptCharacterLimit
+                  ? 'text-[var(--beatcanvas-warning)]'
+                  : 'text-[var(--beat-text-3)]'
+              )}
+            >
+              {promptCharacterCount}/{promptCharacterLimit}
+            </span>
+            <button
+              type="button"
+              onClick={onGenerate}
+              disabled={isBusy || !draft.prompt.trim() || !selectedModel}
+              className={cn(
+                composerGenerateButtonClassName,
+                'active:translate-y-px'
+              )}
+              aria-label={primaryButtonLabel}
+            >
+              {isBusy ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : hasExistingTakes ? (
+                <RotateCw className="size-3.5" />
+              ) : (
+                <ArrowUp className="size-3.5" />
+              )}
+              {hasExistingTakes ? (
+                <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--beat-surface-2)] px-1 text-[9px] font-bold tabular-nums text-[var(--beat-text-1)] ring-1 ring-white/12">
+                  {takeCount}
+                </span>
+              ) : null}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/studio/studio-generation-feed.tsx
+++ b/src/components/studio/studio-generation-feed.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { Loader2, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { composerCardClassName } from '@/components/app/composer-styles';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { ProjectGenerationItem } from '@/core/effects/project-generations';
+import { formatStudioHistoryDateTime } from '@/core/studio/studio-history';
+import { useTranslations } from '@/core/workspace-lib/shims/next-intl';
+import { cn } from '@/lib/utils';
+
+const chipClassName =
+  'inline-flex h-6 items-center rounded-full border border-white/[0.09] bg-white/[0.035] px-2 text-[11px] font-medium text-[var(--beat-text-1)]';
+
+function StudioHistoryItem({
+  item,
+  onOpen,
+}: {
+  item: ProjectGenerationItem;
+  onOpen: () => void;
+}) {
+  const t = useTranslations('AppShell.studio.feed');
+  const isBusy = item.status === 'pending' || item.status === 'processing';
+  const isVideo = item.mediaType === 'video';
+  const previewUrl = item.resultUrl;
+
+  return (
+    <article className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={chipClassName}>
+          {isVideo ? t('video') : t('image')}
+        </span>
+        <span className={chipClassName}>
+          {item.modelName || item.modelId || t('result')}
+        </span>
+        <span className="text-[12px] text-[var(--beat-text-3)]">
+          {formatStudioHistoryDateTime(new Date(item.createdAt))}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={t('openPreview')}
+        className="block text-left"
+      >
+        <div className="h-[240px] w-[min(100%,400px)] overflow-hidden rounded-[16px] bg-black/20">
+          {previewUrl ? (
+            isVideo ? (
+              <video
+                src={previewUrl}
+                preload="metadata"
+                muted
+                playsInline
+                className="h-full w-full object-contain"
+              />
+            ) : (
+              <img
+                src={previewUrl}
+                alt=""
+                className="block h-full w-full object-contain"
+              />
+            )
+          ) : (
+            <div className="flex h-full items-center justify-center text-[12px] text-[var(--beat-text-3)]">
+              {isBusy ? (
+                <Loader2 className="size-5 animate-spin" />
+              ) : (
+                t('noPrompt')
+              )}
+            </div>
+          )}
+        </div>
+      </button>
+    </article>
+  );
+}
+
+export function StudioGenerationFeed({
+  items,
+}: {
+  items: ProjectGenerationItem[];
+}) {
+  const t = useTranslations('AppShell.studio.feed');
+  const endRef = useRef<HTMLDivElement | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = items.find((item) => item.id === selectedId) ?? null;
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ block: 'end' });
+  }, [items.length, items.at(-1)?.status, items.at(-1)?.resultUrl]);
+
+  return (
+    <>
+      <section className="mx-auto flex w-full max-w-[1138px] flex-col gap-5 pb-4">
+        {items.map((item) => (
+          <StudioHistoryItem
+            key={item.id}
+            item={item}
+            onOpen={() => setSelectedId(item.id)}
+          />
+        ))}
+        <div ref={endRef} />
+      </section>
+
+      <Dialog
+        open={Boolean(selected)}
+        onOpenChange={(open) => {
+          if (!open) setSelectedId(null);
+        }}
+      >
+        {selected ? (
+          <DialogContent
+            showCloseButton={false}
+            className={cn(
+              'h-[min(900px,calc(100vh-2.25rem))] w-[min(1680px,calc(100vw-2.25rem))] max-w-none overflow-hidden p-0 text-[var(--beat-text-1)] sm:max-w-none',
+              composerCardClassName
+            )}
+          >
+            <DialogTitle className="sr-only">
+              {selected.modelName || t('result')}
+            </DialogTitle>
+            <DialogClose className="absolute right-2 top-2 z-30 inline-flex size-10 items-center justify-center rounded-full border border-white/[0.09] bg-black/45 text-white/88 backdrop-blur-xl">
+              <X className="size-5" />
+              <span className="sr-only">{t('closePreview')}</span>
+            </DialogClose>
+            <div className="grid h-full min-h-0 xl:grid-cols-[minmax(0,1.12fr)_420px]">
+              <div className="relative flex items-center justify-center overflow-hidden bg-black/40 px-6 py-6">
+                {selected.mediaType === 'video' && selected.resultUrl ? (
+                  <video
+                    src={selected.resultUrl}
+                    controls
+                    className="max-h-full max-w-full rounded-[var(--beat-radius-sm)] bg-black object-contain"
+                  />
+                ) : selected.resultUrl ? (
+                  <img
+                    src={selected.resultUrl}
+                    alt={selected.prompt || selected.modelName || t('result')}
+                    className="max-h-full max-w-full object-contain"
+                  />
+                ) : null}
+              </div>
+              <div className="flex min-h-0 flex-col border-t border-white/[0.08] xl:border-l xl:border-t-0">
+                <div className="flex flex-wrap items-center gap-1.5 border-b border-white/[0.08] px-6 py-5">
+                  <span className={chipClassName}>
+                    {selected.mediaType === 'video' ? t('video') : t('image')}
+                  </span>
+                  <span className={chipClassName}>
+                    {selected.modelName || selected.modelId || t('result')}
+                  </span>
+                  {selected.paramsLabel ? (
+                    <span
+                      className={cn(chipClassName, 'text-[var(--beat-text-2)]')}
+                    >
+                      {selected.paramsLabel}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="flex-1 space-y-5 overflow-y-auto px-6 py-6">
+                  <div className="flex h-[min(260px,34vh)] min-h-[180px] flex-col rounded-[var(--beat-radius-sm)] border border-white/[0.09] bg-white/[0.03] p-4">
+                    <p className="shrink-0 text-[13px] text-[var(--beat-text-3)]">
+                      {t('prompt')}
+                    </p>
+                    <div className="mt-3 min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1 [scrollbar-gutter:stable]">
+                      <p className="whitespace-pre-wrap break-words text-[14px] leading-7 text-[var(--beat-text-2)]">
+                        {selected.prompt || t('noPrompt')}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="rounded-[var(--beat-radius-sm)] border border-white/[0.09] bg-white/[0.03] px-4 py-1">
+                    <div className="flex items-start justify-between gap-6 border-b border-white/[0.08] py-3">
+                      <span className="text-sm text-[var(--beat-text-3)]">
+                        {t('model')}
+                      </span>
+                      <span className="text-right text-sm text-[var(--beat-text-1)]">
+                        {selected.modelName || selected.modelId || t('result')}
+                      </span>
+                    </div>
+                    <div className="flex items-start justify-between gap-6 py-3">
+                      <span className="text-sm text-[var(--beat-text-3)]">
+                        {t('params')}
+                      </span>
+                      <span className="text-right text-sm text-[var(--beat-text-1)]">
+                        {selected.paramsLabel || '—'}
+                      </span>
+                    </div>
+                  </div>
+                  {selected.referenceImages.length > 0 ||
+                  selected.referenceVideos.length > 0 ? (
+                    <div className="rounded-[var(--beat-radius-sm)] border border-white/[0.09] bg-white/[0.03] p-4">
+                      <p className="text-[13px] text-[var(--beat-text-3)]">
+                        {t('references')}
+                      </p>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {selected.referenceImages.map((url) => (
+                          <a
+                            key={url}
+                            href={url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="block size-16 overflow-hidden rounded-[10px] bg-black/30"
+                          >
+                            <img
+                              src={url}
+                              alt=""
+                              className="h-full w-full object-cover"
+                            />
+                          </a>
+                        ))}
+                        {selected.referenceVideos.map((url) => (
+                          <video
+                            key={url}
+                            src={url}
+                            muted
+                            playsInline
+                            preload="metadata"
+                            className="size-16 rounded-[10px] bg-black/30 object-cover"
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          </DialogContent>
+        ) : null}
+      </Dialog>
+    </>
+  );
+}

--- a/src/config/workspace-modes.test.ts
+++ b/src/config/workspace-modes.test.ts
@@ -3,10 +3,11 @@ import test from 'node:test';
 
 import { resolveWorkspaceMode, workspaceModes } from './workspace-modes';
 
-test('workspace modes expose one canonical Studio and Canvas switch', () => {
-  assert.deepEqual(workspaceModes, ['studio', 'canvas']);
+test('workspace modes expose Studio, Canvas, and Assets', () => {
+  assert.deepEqual(workspaceModes, ['studio', 'canvas', 'assets']);
   assert.equal(resolveWorkspaceMode('studio'), 'studio');
   assert.equal(resolveWorkspaceMode('canvas'), 'canvas');
+  assert.equal(resolveWorkspaceMode('assets'), 'assets');
   assert.equal(resolveWorkspaceMode('unknown'), 'canvas');
   assert.equal(resolveWorkspaceMode(undefined), 'canvas');
 });

--- a/src/config/workspace-modes.ts
+++ b/src/config/workspace-modes.ts
@@ -1,4 +1,4 @@
-export const workspaceModes = ['studio', 'canvas'] as const;
+export const workspaceModes = ['studio', 'canvas', 'assets'] as const;
 
 export type WorkspaceMode = (typeof workspaceModes)[number];
 
@@ -8,4 +8,10 @@ export function resolveWorkspaceMode(value?: string | null): WorkspaceMode {
   return workspaceModes.includes(value as WorkspaceMode)
     ? (value as WorkspaceMode)
     : defaultWorkspaceMode;
+}
+
+export function workspaceModePath(mode: WorkspaceMode) {
+  if (mode === 'studio') return '/studio';
+  if (mode === 'assets') return '/assets';
+  return '/canvas';
 }

--- a/src/core/effects/project-generations.test.ts
+++ b/src/core/effects/project-generations.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  toChronologicalProjectGenerationItems,
+  toProjectGenerationItem,
+} from './project-generations';
+
+test('maps a stored generation onto the studio feed card', () => {
+  const item = toProjectGenerationItem({
+    id: 'gen-1',
+    status: 'succeeded',
+    submittedPrompt: 'A quiet coastal village',
+    effectId: 1,
+    input: {
+      model: 'veo-3.1',
+      mode: 'fast',
+      aspect_ratio: '9:16',
+      wmOutputQuality: '1k',
+      image_urls: ['https://media.beatapi.io/inputs/ref.png'],
+    },
+    output: { result_url: 'https://media.beatapi.io/outputs/gen-1.mp4' },
+    error: null,
+    createdAt: new Date('2026-08-22T00:00:00.000Z'),
+  });
+
+  assert.equal(item.modelId, 'veo-3.1');
+  assert.equal(item.modelName, 'Veo 3.1');
+  assert.equal(item.mediaType, 'video');
+  assert.equal(item.resultUrl, 'https://media.beatapi.io/outputs/gen-1.mp4');
+  assert.equal(item.prompt, 'A quiet coastal village');
+  assert.equal(item.paramsLabel, 'Fast · 9:16 · 1K');
+  assert.equal(item.aspectRatio, '9:16');
+  assert.deepEqual(item.referenceImages, [
+    'https://media.beatapi.io/inputs/ref.png',
+  ]);
+});
+
+test('keeps the latest limited generations in chronological feed order', () => {
+  const row = (id: string, createdAt: string) => ({
+    id,
+    status: 'succeeded',
+    submittedPrompt: null,
+    effectId: 1,
+    input: {},
+    output: null,
+    error: null,
+    createdAt,
+  });
+
+  const items = toChronologicalProjectGenerationItems([
+    row('newest', '2026-08-23T02:00:00.000Z'),
+    row('older', '2026-08-23T01:00:00.000Z'),
+  ]);
+
+  assert.deepEqual(items.map((item) => item.id), ['older', 'newest']);
+});

--- a/src/core/effects/project-generations.ts
+++ b/src/core/effects/project-generations.ts
@@ -1,0 +1,141 @@
+import { desc, eq } from 'drizzle-orm';
+
+import { generationHistory } from '@/config/db/schema';
+import { getWorkspaceEffectRegistryEntryByEffectId } from '@/core/effects/effect-registry';
+import { resolveOutputMedia } from '@/core/effects/output-media';
+import { getDb } from '@/core/workspace-lib/db-adapter';
+
+import type { GenerationStatus } from './record-generation';
+
+export type ProjectGenerationItem = {
+  id: string;
+  status: GenerationStatus;
+  prompt: string | null;
+  modelId: string | null;
+  modelName: string | null;
+  mediaType: 'image' | 'video';
+  resultUrl: string | null;
+  paramsLabel: string | null;
+  aspectRatio: string | null;
+  outputQuality: string | null;
+  mode: string | null;
+  duration: string | null;
+  referenceImages: string[];
+  referenceVideos: string[];
+  error: string | null;
+  createdAt: string;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+
+const readString = (value: unknown) =>
+  typeof value === 'string' && value.trim() ? value.trim() : null;
+
+const readUrlList = (...values: unknown[]) => {
+  const urls: string[] = [];
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      urls.push(value.trim());
+      continue;
+    }
+    if (Array.isArray(value)) {
+      urls.push(
+        ...value.filter(
+          (item): item is string => typeof item === 'string' && Boolean(item.trim())
+        ).map((item) => item.trim())
+      );
+    }
+  }
+  return [...new Set(urls)];
+};
+
+const formatParamsLabel = (input: Record<string, unknown> | null) => {
+  if (!input) return null;
+  const mode =
+    input.mode === 'fast'
+      ? 'Fast'
+      : input.mode === 'lite'
+        ? 'Lite'
+        : input.mode === 'quality'
+          ? 'Quality'
+          : null;
+  const duration = readString(input.wmDuration);
+  const aspectRatio = readString(input.aspect_ratio);
+  const quality = readString(input.wmOutputQuality)?.toUpperCase() ?? null;
+  const parts = [mode, duration, aspectRatio, quality].filter(
+    (value): value is string => Boolean(value)
+  );
+  return parts.length > 0 ? parts.join(' · ') : null;
+};
+
+type ProjectGenerationRow = {
+  id: string;
+  status: string;
+  submittedPrompt: string | null;
+  effectId: number;
+  input: unknown;
+  output: unknown;
+  error: string | null;
+  createdAt: Date | string;
+};
+
+export const toProjectGenerationItem = (
+  row: ProjectGenerationRow
+): ProjectGenerationItem => {
+  const entry = getWorkspaceEffectRegistryEntryByEffectId(row.effectId);
+  const input = asRecord(row.input);
+  const media = resolveOutputMedia(row.output);
+  const createdAt =
+    row.createdAt instanceof Date
+      ? row.createdAt.toISOString()
+      : new Date(row.createdAt).toISOString();
+
+  return {
+    id: row.id,
+    status: row.status as GenerationStatus,
+    prompt: row.submittedPrompt,
+    modelId: readString(input?.model) ?? entry?.id ?? null,
+    modelName: entry?.name ?? null,
+    mediaType: entry?.workspaceType === 'ai-image' ? 'image' : 'video',
+    resultUrl: media.resultUrl,
+    paramsLabel: formatParamsLabel(input),
+    aspectRatio: readString(input?.aspect_ratio),
+    outputQuality: readString(input?.wmOutputQuality),
+    mode: readString(input?.mode),
+    duration: readString(input?.wmDuration),
+    referenceImages: readUrlList(
+      input?.image_urls,
+      input?.image_url,
+      input?.last_frame
+    ),
+    referenceVideos: readUrlList(input?.video_urls, input?.video_url),
+    error: row.error,
+    createdAt,
+  };
+};
+
+export const toChronologicalProjectGenerationItems = (
+  newestFirstRows: ProjectGenerationRow[]
+) => [...newestFirstRows].reverse().map(toProjectGenerationItem);
+
+export async function listProjectGenerations(projectId: string, limit = 80) {
+  const db = await getDb();
+  const rows = await db
+    .select({
+      id: generationHistory.id,
+      status: generationHistory.status,
+      submittedPrompt: generationHistory.submittedPrompt,
+      effectId: generationHistory.effectId,
+      input: generationHistory.input,
+      output: generationHistory.output,
+      error: generationHistory.error,
+      createdAt: generationHistory.createdAt,
+    })
+    .from(generationHistory)
+    .where(eq(generationHistory.projectId, projectId))
+    .orderBy(desc(generationHistory.createdAt))
+    .limit(limit);
+
+  return toChronologicalProjectGenerationItems(rows);
+}

--- a/src/core/projects/project-entry.ts
+++ b/src/core/projects/project-entry.ts
@@ -1,6 +1,8 @@
-import { Routes } from '@/core/workspace-lib/shims/routes';
 import type { Locale } from '@/core/workspace-lib/shims/next-intl';
-import { resolveWorkspaceMode } from '@/config/workspace-modes';
+import {
+  resolveWorkspaceMode,
+  workspaceModePath,
+} from '@/config/workspace-modes';
 import { formatProjectActivityDate } from './format-project-activity-date';
 
 const getLocalizedRoute = (route: string, locale?: string | null) =>
@@ -59,8 +61,7 @@ export function buildCreateProjectPath({ ...intent }: ProjectWorkspaceIntent = {
   const { mode, ...searchIntent } = intent;
   const searchParams = buildProjectEntrySearchParams(searchIntent);
   const query = searchParams.toString();
-  const workspacePath =
-    resolveWorkspaceMode(mode) === 'studio' ? Routes.Studio : Routes.Canvas;
+  const workspacePath = workspaceModePath(resolveWorkspaceMode(mode));
   return query ? `${workspacePath}?${query}` : workspacePath;
 }
 
@@ -74,9 +75,7 @@ export function buildLocalizedCreateProjectPath({
 }
 
 export function buildProjectDetailPath(projectId: string, mode?: string) {
-  const workspacePath =
-    resolveWorkspaceMode(mode) === 'studio' ? Routes.Studio : Routes.Canvas;
-  return `${workspacePath}/${projectId}`;
+  return `${workspaceModePath(resolveWorkspaceMode(mode))}/${projectId}`;
 }
 
 export function buildProjectDetailPathWithIntent({

--- a/src/core/studio/studio-draft.ts
+++ b/src/core/studio/studio-draft.ts
@@ -1,0 +1,51 @@
+import { getCompatibleDraftModelSettings } from '@/core/beatcanvas/composer';
+import type {
+  CanvasCardMediaType,
+  CanvasGenerationCard,
+} from '@/core/beatcanvas/canvas-types';
+import { getDraftDefaultsFromModel } from '@/core/beatcanvas/draft-defaults';
+import type { WorkspaceModelOption } from '@/core/effects/workspace-models';
+
+export const STUDIO_DRAFT_ID = 'studio-draft';
+
+export const createStudioDraftCard = ({
+  type,
+  model,
+  prompt = '',
+}: {
+  type: CanvasCardMediaType;
+  model: WorkspaceModelOption | null;
+  prompt?: string;
+}): CanvasGenerationCard => {
+  const defaults = getDraftDefaultsFromModel(type, model);
+
+  return {
+    id: STUDIO_DRAFT_ID,
+    kind: 'generation',
+    name: 'Studio draft',
+    url: null,
+    prompt,
+    referenceCardIds: [],
+    workflowTemplateId: null,
+    status: 'idle',
+    error: null,
+    ...defaults,
+    type,
+    sourceGenerationId: null,
+  };
+};
+
+export const applyStudioDraftModel = ({
+  draft,
+  model,
+}: {
+  draft: CanvasGenerationCard;
+  model: WorkspaceModelOption;
+}): CanvasGenerationCard => ({
+  ...draft,
+  modelId: model.id,
+  ...getCompatibleDraftModelSettings({
+    draftCard: draft,
+    model,
+  }),
+});

--- a/src/core/studio/studio-history.test.ts
+++ b/src/core/studio/studio-history.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  formatStudioHistoryDateTime,
+  getStudioHistoryMediaFrame,
+} from './studio-history';
+
+test('formats history date and time together', () => {
+  assert.equal(
+    formatStudioHistoryDateTime(new Date(2026, 2, 25, 14, 34)),
+    '03-25 14:34'
+  );
+});
+
+test('sizes history media to the stored aspect ratio', () => {
+  assert.deepEqual(getStudioHistoryMediaFrame('16:9'), {
+    aspectRatio: '16 / 9',
+    orientation: 'landscape',
+  });
+  assert.deepEqual(getStudioHistoryMediaFrame('9:16'), {
+    aspectRatio: '9 / 16',
+    orientation: 'portrait',
+  });
+  assert.equal(getStudioHistoryMediaFrame('1:1').orientation, 'square');
+  assert.equal(
+    getStudioHistoryMediaFrame(null, { width: 1920, height: 1080 })
+      .orientation,
+    'landscape'
+  );
+});

--- a/src/core/studio/studio-history.ts
+++ b/src/core/studio/studio-history.ts
@@ -1,0 +1,31 @@
+export type StudioHistoryMediaOrientation =
+  | 'portrait'
+  | 'landscape'
+  | 'square';
+
+export type StudioHistoryMediaFrame = {
+  aspectRatio: string;
+  orientation: StudioHistoryMediaOrientation;
+};
+
+const pad = (value: number) => String(value).padStart(2, '0');
+
+export function formatStudioHistoryDateTime(date: Date) {
+  return `${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+export function getStudioHistoryMediaFrame(
+  aspectRatio: string | null,
+  natural?: { width: number; height: number } | null
+): StudioHistoryMediaFrame {
+  const match = aspectRatio?.match(/^(\d+(?:\.\d+)?)\s*:\s*(\d+(?:\.\d+)?)$/);
+  const width = natural?.width || (match ? Number(match[1]) : 16);
+  const height = natural?.height || (match ? Number(match[2]) : 9);
+  const ratio = width / height;
+
+  return {
+    aspectRatio: `${width} / ${height}`,
+    orientation:
+      ratio < 0.95 ? 'portrait' : ratio > 1.05 ? 'landscape' : 'square',
+  };
+}

--- a/src/core/studio/studio-runtime.test.ts
+++ b/src/core/studio/studio-runtime.test.ts
@@ -36,3 +36,28 @@ test('builds a text-to-video request without inventing a second backend', () => 
   assert.equal(input.prompt, 'Slow cinematic camera move');
   assert.equal(input.generationType, 'TEXT_2_VIDEO');
 });
+
+test('passes Veo quality mode and resolution through the shared studio input', () => {
+  const veo = getStudioModels('video').find((item) => item.id === 'veo-3.1');
+  assert.ok(veo);
+  assert.deepEqual(veo.modeOptions, ['quality', 'fast', 'lite']);
+  assert.deepEqual(
+    buildStudioEffectInput({
+      media: 'video',
+      model: veo,
+      prompt: 'Coastal sunrise',
+      aspectRatio: '16:9',
+      mode: 'lite',
+      outputQuality: '4k',
+      duration: '8s',
+    }),
+    {
+      prompt: 'Coastal sunrise',
+      aspect_ratio: '16:9',
+      generationType: 'TEXT_2_VIDEO',
+      wmDuration: '8s',
+      mode: 'lite',
+      wmOutputQuality: '4k',
+    }
+  );
+});

--- a/src/core/studio/studio-runtime.ts
+++ b/src/core/studio/studio-runtime.ts
@@ -15,11 +15,21 @@ export function buildStudioEffectInput({
   model,
   prompt,
   aspectRatio,
+  duration,
+  outputQuality,
+  mode,
+  quality,
+  language,
 }: {
   media: StudioMedia;
   model: WorkspaceModelOption;
   prompt: string;
   aspectRatio: string;
+  duration?: string;
+  outputQuality?: string;
+  mode?: string;
+  quality?: string;
+  language?: string;
 }): Record<string, unknown> {
   const input: Record<string, unknown> = {
     prompt: prompt.trim(),
@@ -27,19 +37,21 @@ export function buildStudioEffectInput({
   };
 
   if (media === 'image') {
-    if (model.defaultOutputQuality) {
-      input.wmOutputQuality = model.defaultOutputQuality;
-    }
-    if (model.defaultQuality) input.quality = model.defaultQuality;
+    const nextOutputQuality = outputQuality ?? model.defaultOutputQuality;
+    if (nextOutputQuality) input.wmOutputQuality = nextOutputQuality;
+    const nextQuality = quality ?? model.defaultQuality;
+    if (nextQuality) input.quality = nextQuality;
     return input;
   }
 
   input.generationType = 'TEXT_2_VIDEO';
-  if (model.defaultDuration) input.wmDuration = model.defaultDuration;
-  if (model.defaultMode) input.mode = model.defaultMode;
-  if (model.defaultOutputQuality) {
-    input.wmOutputQuality = model.defaultOutputQuality;
-  }
-  if (model.defaultLanguage) input.language = model.defaultLanguage;
+  const nextDuration = duration ?? model.defaultDuration;
+  if (nextDuration) input.wmDuration = nextDuration;
+  const nextMode = mode ?? model.defaultMode;
+  if (nextMode) input.mode = nextMode;
+  const nextOutputQuality = outputQuality ?? model.defaultOutputQuality;
+  if (nextOutputQuality) input.wmOutputQuality = nextOutputQuality;
+  const nextLanguage = language ?? model.defaultLanguage;
+  if (nextLanguage) input.language = nextLanguage;
   return input;
 }

--- a/src/core/workspace-lib/app/workspace-client-api.ts
+++ b/src/core/workspace-lib/app/workspace-client-api.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceProjectCardItem } from '@/components/app/workspace-project-hub';
+import type { ProjectGenerationItem } from '@/core/effects/project-generations';
 import { apiJsonDelete, apiJsonGet } from '@/lib/api-client';
 
 export type RecentAsset = {
@@ -35,4 +36,10 @@ export async function fetchWorkspaceProjects(): Promise<{
 
 export async function deleteWorkspaceProjects(projectIds: string[]) {
   return apiJsonDelete<{ success: true }>('/api/app/projects', { projectIds });
+}
+
+export async function fetchProjectGenerations(projectId: string) {
+  return apiJsonGet<{ items: ProjectGenerationItem[] }>(
+    `/api/app/projects/${encodeURIComponent(projectId)}/generations`
+  );
 }

--- a/src/core/workspace-lib/app/workspace-query-invalidation.ts
+++ b/src/core/workspace-lib/app/workspace-query-invalidation.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import {
   effectMetadataKeys,
   generationStatusKeys,
+  projectGenerationsKeys,
   recentAssetsKeys,
   workspaceModelsKeys,
   workspaceProjectsKeys,
@@ -14,6 +15,7 @@ export async function invalidateWorkspaceAfterGeneration(
     queryClient.invalidateQueries({ queryKey: recentAssetsKeys.all }),
     queryClient.invalidateQueries({ queryKey: workspaceProjectsKeys.all }),
     queryClient.invalidateQueries({ queryKey: generationStatusKeys.all }),
+    queryClient.invalidateQueries({ queryKey: projectGenerationsKeys.all }),
   ]);
 }
 

--- a/src/core/workspace-lib/app/workspace-query-keys.ts
+++ b/src/core/workspace-lib/app/workspace-query-keys.ts
@@ -31,3 +31,9 @@ export const generationStatusKeys = {
   byTask: (wmTaskId: string, effectId: number) =>
     [...generationStatusKeys.all, wmTaskId, effectId] as const,
 };
+
+export const projectGenerationsKeys = {
+  all: ['project-generations'] as const,
+  list: (projectId: string) =>
+    [...projectGenerationsKeys.all, 'list', projectId] as const,
+};

--- a/src/core/workspace-lib/shims/routes.ts
+++ b/src/core/workspace-lib/shims/routes.ts
@@ -2,4 +2,5 @@ export enum Routes {
   History = '/projects',
   Studio = '/studio',
   Canvas = '/canvas',
+  Assets = '/assets',
 }

--- a/src/lib/i18n-ui-copy-regression.test.ts
+++ b/src/lib/i18n-ui-copy-regression.test.ts
@@ -37,6 +37,6 @@ test('workspace shell exposes projects, Studio, Canvas, assets, and provider con
   assert.match(source, /href="\/"/);
   assert.match(source, /\/studio\//);
   assert.match(source, /\/canvas\//);
-  assert.match(source, /ProjectAssetsDialog/);
+  assert.match(source, /\/assets\//);
   assert.match(source, /WorkspaceApiConfigDialog/);
 });

--- a/src/routes/-workspace-project-route.client-boundary.test.ts
+++ b/src/routes/-workspace-project-route.client-boundary.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-for (const routeFile of ['./studio/$projectId.tsx', './canvas/$projectId.tsx']) {
+for (const routeFile of [
+  './studio/$projectId.tsx',
+  './canvas/$projectId.tsx',
+  './assets/$projectId.tsx',
+]) {
   test(`keeps ${routeFile} data-loaded but client rendered`, () => {
     const source = readFileSync(new URL(routeFile, import.meta.url), 'utf8');
 

--- a/src/routes/api/app/projects/$projectId/generations.ts
+++ b/src/routes/api/app/projects/$projectId/generations.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { listProjectGenerations } from '@/core/effects/project-generations';
+import { getProject } from '@/core/projects/projects';
+
+async function GET({ params }: { params: { projectId: string } }) {
+  const project = await getProject({ projectId: params.projectId });
+  if (!project) {
+    return Response.json({ error: 'Project not found' }, { status: 404 });
+  }
+
+  const items = await listProjectGenerations(params.projectId);
+  return Response.json({ items });
+}
+
+export const Route = createFileRoute('/api/app/projects/$projectId/generations')(
+  {
+    server: { handlers: { GET } },
+  }
+);

--- a/src/routes/assets/$projectId.tsx
+++ b/src/routes/assets/$projectId.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { WorkspaceProjectRoutePage } from '@/components/app/workspace-project-route-page';
+import { loadWorkspaceProjectRoute } from '@/core/projects/workspace-project-route-loader';
+
+export const Route = createFileRoute('/assets/$projectId')({
+  ssr: 'data-only',
+  loader: ({ params }) =>
+    loadWorkspaceProjectRoute({
+      projectId: params.projectId,
+      search: {},
+      workspaceMode: 'assets',
+    }),
+  component: AssetsProjectRouteComponent,
+});
+
+function AssetsProjectRouteComponent() {
+  return <WorkspaceProjectRoutePage data={Route.useLoaderData()} />;
+}

--- a/src/routes/assets/route.tsx
+++ b/src/routes/assets/route.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/assets')({
+  component: Outlet,
+});


### PR DESCRIPTION
## Summary
- add a project-scoped Assets workspace shared with Studio and Canvas
- add a persistent Studio generation feed, preview details, and full model parameter controls
- preserve full project names, show the latest 80 generations in chronological order, and keep local demo media out of Git
- synchronize English/Chinese copy and public architecture documentation

## Verification
- pnpm build
- pnpm typecheck
- pnpm test: 218 passed, 0 failed
- pnpm i18n:check: 543 English / 543 Chinese keys
- pnpm audit --prod --audit-level high: no known vulnerabilities
- staged security scan: 45 feature files and 5 documentation files, no findings

## Review
- pre-landing code review: clean
- design review lite: clean
- no authentication, billing, payment, credits, or SaaS modules added

## Local-only exclusions
- public/demo-assets/ remains local and is ignored
- local databases, provider keys, build output, and generated route/i18n files are not included

## Documentation
- README.md and README.zh-CN.md: added the project-scoped Assets view and updated data flow
- ARCHITECTURE.md and WORKSPACE_MODES.md: documented Studio, Canvas, and Assets as three shared project views
- DESIGN.md and AGENTS.md: aligned local-first product boundaries and cold-blue Canvas semantics