### PR TITLE
feat: improve canvas generation results and retries

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -415,6 +415,10 @@
         "shapes": {
           "imageGeneration": "Image generation",
           "videoGeneration": "Video generation",
+          "videoAnalysis": "Video analysis",
+          "analysisReport": "Analysis report",
+          "analysisComplete": "Analysis complete",
+          "analysisReportReady": "Report added after this node",
           "image": "Image",
           "video": "Video",
           "previewLoading": "Loading preview...",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -416,6 +416,10 @@
         "shapes": {
           "imageGeneration": "图片生成",
           "videoGeneration": "视频生成",
+          "videoAnalysis": "视频分析",
+          "analysisReport": "分析报告",
+          "analysisComplete": "分析完成",
+          "analysisReportReady": "报告已生成在此节点后方",
           "image": "图片",
           "video": "视频",
           "previewLoading": "正在加载预览...",

--- a/src/components/beatcanvas/beatcanvas-media-preview.test.ts
+++ b/src/components/beatcanvas/beatcanvas-media-preview.test.ts
@@ -5,6 +5,7 @@ import type { CanvasCard } from '@/core/beatcanvas/canvas-types';
 
 import {
   getPreviewableCanvasCardFromSelection,
+  isDownloadableCanvasCard,
   isPreviewableCanvasCard,
   resolveBatchCanvasCardSelection,
 } from './beatcanvas-media-preview';
@@ -31,8 +32,9 @@ const makeCard = (overrides: Partial<CanvasCard>): CanvasCard => ({
   ...overrides,
 });
 
-test('recognizes real image and video asset cards as previewable', () => {
+test('recognizes real asset and generated media cards as previewable and downloadable', () => {
   assert.equal(isPreviewableCanvasCard(makeCard({})), true);
+  assert.equal(isDownloadableCanvasCard(makeCard({})), true);
   assert.equal(
     isPreviewableCanvasCard(
       makeCard({ url: 'data:image/svg+xml;charset=utf-8,%3Csvg%3E' })
@@ -42,6 +44,22 @@ test('recognizes real image and video asset cards as previewable', () => {
   assert.equal(isPreviewableCanvasCard(makeCard({ type: 'video' })), true);
   assert.equal(
     isPreviewableCanvasCard(makeCard({ kind: 'generation' })),
+    true
+  );
+  assert.equal(
+    isDownloadableCanvasCard(makeCard({ kind: 'generation' })),
+    true
+  );
+  assert.equal(
+    isPreviewableCanvasCard(
+      makeCard({ kind: 'output', type: 'video' })
+    ),
+    true
+  );
+  assert.equal(
+    isPreviewableCanvasCard(
+      makeCard({ kind: 'generation', generationMode: 'analysis' })
+    ),
     false
   );
 });

--- a/src/components/beatcanvas/beatcanvas-media-preview.ts
+++ b/src/components/beatcanvas/beatcanvas-media-preview.ts
@@ -1,14 +1,24 @@
 import type { CanvasCard } from '@/core/beatcanvas/canvas-types';
 
-export const isPreviewableCanvasCard = (
+export const isDownloadableCanvasCard = (
   card: CanvasCard | null | undefined
 ) =>
   Boolean(
     card?.url &&
-      card.kind === 'asset' &&
+      card.generationMode !== 'analysis' &&
+      !(
+        card.type === 'image' && card.url.startsWith('data:image/svg+xml')
+      )
+  );
+
+export const isPreviewableCanvasCard = (
+  card: CanvasCard | null | undefined
+) =>
+  Boolean(
+    isDownloadableCanvasCard(card) &&
+      card &&
       (card.type === 'video' ||
-        (card.type === 'image' &&
-          !card.url.startsWith('data:image/svg+xml')))
+        card.type === 'image')
   );
 
 export const getPreviewableCanvasCardFromSelection = ({

--- a/src/components/beatcanvas/beatcanvas-shell.tsx
+++ b/src/components/beatcanvas/beatcanvas-shell.tsx
@@ -61,6 +61,7 @@ import { registerCardConnectorCallback } from './beatcanvas-card-connector-bridg
 import type { BeatCanvasPreviewMedia } from './beatcanvas-media-preview-overlay';
 import {
   getPreviewableCanvasCardFromSelection,
+  isDownloadableCanvasCard,
   resolveBatchCanvasCardSelection,
 } from './beatcanvas-media-preview';
 import BeatCanvasSidebar from './beatcanvas-sidebar';
@@ -856,22 +857,12 @@ export function BeatCanvasShell({
     [canvasCards, selectedCanvasCardIds, selectedGroupCards]
   );
 
-  const isDownloadableCanvasCard = useCallback(
-    (card: CanvasCard | null | undefined) => {
-      if (!card?.url || card.kind !== 'asset') {
-        return false;
-      }
-
-      return !card.url.startsWith('data:image/svg+xml');
-    },
-    []
-  );
   const downloadableGroupCards = useMemo(
     () =>
       effectiveSelectedGroupCards.filter((card: CanvasCard) =>
         isDownloadableCanvasCard(card)
       ),
-    [effectiveSelectedGroupCards, isDownloadableCanvasCard]
+    [effectiveSelectedGroupCards]
   );
   const isSingleDownloadable = isDownloadableCanvasCard(selectedSingleCard);
   const previewableSelectedCard = useMemo(

--- a/src/components/beatcanvas/nodes/beatcanvas-node-copy.ts
+++ b/src/components/beatcanvas/nodes/beatcanvas-node-copy.ts
@@ -6,6 +6,9 @@ type BeatCanvasNodeLocale = 'en' | 'zh';
 type BeatCanvasNodeCopy = {
   imageGeneration: string;
   videoGeneration: string;
+  videoAnalysis: string;
+  analysisComplete: string;
+  analysisReportReady: string;
   image: string;
   video: string;
   previewLoading: string;
@@ -49,6 +52,18 @@ const getNodeCopyForLocale = (locale: BeatCanvasNodeLocale): BeatCanvasNodeCopy 
     { locale }
   ),
   videoGeneration: m['AppShell.studio.canvas.shapes.videoGeneration'](
+    {},
+    { locale }
+  ),
+  videoAnalysis: m['AppShell.studio.canvas.shapes.videoAnalysis'](
+    {},
+    { locale }
+  ),
+  analysisComplete: m['AppShell.studio.canvas.shapes.analysisComplete'](
+    {},
+    { locale }
+  ),
+  analysisReportReady: m['AppShell.studio.canvas.shapes.analysisReportReady'](
     {},
     { locale }
   ),

--- a/src/components/beatcanvas/nodes/generation-card-node-interaction.test.ts
+++ b/src/components/beatcanvas/nodes/generation-card-node-interaction.test.ts
@@ -15,7 +15,7 @@ test('generation media remains a full-card drag surface', () => {
   );
   assert.match(
     source,
-    /<img[\s\S]*?draggable=\{false\}\s+className="nowheel"/
+    /<img[\s\S]*?draggable=\{false\}[\s\S]*?className="nowheel"/
   );
 });
 
@@ -29,6 +29,21 @@ test('generation node leaves prompt and parameters to the attached Composer', ()
   assert.match(source, /Take \$\{take\.takeNumber\}/);
 });
 
+test('analysis reports expose selectable read-only text without dragging the node', () => {
+  assert.match(
+    source,
+    /<textarea[\s\S]*?readOnly[\s\S]*?value=\{latestOutputText\}/
+  );
+  assert.match(
+    source,
+    /className="nodrag nopan nowheel[^"]*cursor-text[^"]*selection:bg-/
+  );
+  assert.match(
+    source,
+    /onPointerDown=\{\(event\) => event\.stopPropagation\(\)\}/
+  );
+});
+
 test('generated videos expose a direct playback entry', () => {
   assert.match(source, /const handlePreviewLatestOutput/);
   assert.match(
@@ -39,4 +54,13 @@ test('generated videos expose a direct playback entry', () => {
     source,
     /<video[\s\S]*?onDoubleClick=\{[\s\S]*?handlePreviewLatestOutput/
   );
+});
+
+test('generated images open the same unified media preview on double click', () => {
+  assert.match(
+    source,
+    /<img[\s\S]*?onDoubleClick=\{[\s\S]*?handlePreviewLatestOutput/
+  );
+  assert.match(source, /type: cardMediaType/);
+  assert.match(source, /cursor: 'zoom-in'/);
 });

--- a/src/components/beatcanvas/nodes/generation-card-node.tsx
+++ b/src/components/beatcanvas/nodes/generation-card-node.tsx
@@ -40,11 +40,16 @@ export function GenerationCardNode({
     isAnalysis = false,
     latestOutputUrl = null,
     latestOutputText = null,
+    analysisReportCount = 0,
     takes = [],
   } = props;
   const isBusy = status === 'pending' || status === 'processing';
   const isFailed = status === 'failed';
-  const hasResult = Boolean(latestOutputUrl || latestOutputText);
+  const hasResult = Boolean(
+    latestOutputUrl ||
+      latestOutputText ||
+      (isAnalysis && analysisReportCount > 0)
+  );
   const isEmptySlot = !hasResult && !isFailed;
   const emptySlotAccent =
     cardMediaType === 'video' ? 'var(--beat-graph)' : 'var(--beat-accent)';
@@ -60,9 +65,11 @@ export function GenerationCardNode({
   const isInsideGroup = Boolean(internalNode?.parentId);
   const displayLabel =
     label ||
-    (cardMediaType === 'image'
-      ? shapeCopy.imageGeneration
-      : shapeCopy.videoGeneration);
+    (isAnalysis
+      ? shapeCopy.videoAnalysis
+      : cardMediaType === 'image'
+        ? shapeCopy.imageGeneration
+        : shapeCopy.videoGeneration);
   const isCompactActionNode = w <= 128 && h <= 128;
   const visibleTakes = takes.slice(-MAX_VISIBLE_TAKES);
   const showTakeStrip =
@@ -91,7 +98,7 @@ export function GenerationCardNode({
   const handlePreviewLatestOutput = () => {
     if (
       !latestOutputUrl ||
-      cardMediaType !== 'video' ||
+      isAnalysis ||
       typeof window === 'undefined'
     ) {
       return;
@@ -99,7 +106,7 @@ export function GenerationCardNode({
     window.dispatchEvent(
       new CustomEvent('beatcanvas:preview-media', {
         detail: {
-          type: 'video',
+          type: cardMediaType,
           url: latestOutputUrl,
           title: displayLabel,
         },
@@ -247,14 +254,34 @@ export function GenerationCardNode({
             ) : null}
             {hasResult ? (
               isAnalysis && latestOutputText ? (
-                <div className="nowheel h-full overflow-y-auto p-4 text-left text-[12px] leading-5 text-[var(--beat-text-2)]">
-                  <div className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--beat-graph)]">
+                <div className="nodrag nopan nowheel flex h-full cursor-default flex-col p-4 text-left">
+                  <div className="mb-2 flex shrink-0 items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--beat-graph)]">
                     <ScanSearch className="size-3.5" />
                     {displayLabel}
                   </div>
-                  <p className="whitespace-pre-wrap break-words">
-                    {latestOutputText}
-                  </p>
+                  <textarea
+                    aria-label={displayLabel}
+                    readOnly
+                    spellCheck={false}
+                    value={latestOutputText}
+                    className="nodrag nopan nowheel min-h-0 flex-1 cursor-text resize-none overflow-y-auto border-0 bg-transparent p-0 text-[12px] leading-5 text-[var(--beat-text-2)] outline-none selection:bg-[rgba(127,176,242,0.28)] selection:text-[var(--beat-text-1)] focus-visible:ring-0"
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onDoubleClick={(event) => event.stopPropagation()}
+                  />
+                </div>
+              ) : isAnalysis && analysisReportCount > 0 ? (
+                <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+                  <div className="grid size-12 place-items-center rounded-2xl border border-[rgba(127,176,242,0.28)] bg-[var(--beat-graph-soft)] text-[var(--beat-graph)] shadow-[0_10px_24px_rgba(0,0,0,0.24)]">
+                    <ScanSearch className="size-6" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <div className="text-[13px] font-semibold text-[var(--beat-text-1)]">
+                      {shapeCopy.analysisComplete}
+                    </div>
+                    <div className="mt-1 text-[11px] leading-4 text-[var(--beat-text-3)]">
+                      {shapeCopy.analysisReportReady}
+                    </div>
+                  </div>
                 </div>
               ) : cardMediaType === 'video' ? (
                 <video
@@ -282,12 +309,18 @@ export function GenerationCardNode({
                   src={latestOutputUrl ?? undefined}
                   alt={displayLabel}
                   draggable={false}
+                  onDoubleClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    handlePreviewLatestOutput();
+                  }}
                   className="nowheel"
                   style={{
                     display: 'block',
                     width: '100%',
                     height: '100%',
                     objectFit: 'cover',
+                    cursor: 'zoom-in',
                   }}
                 />
               )
@@ -303,30 +336,38 @@ export function GenerationCardNode({
                   gap: 12,
                 }}
               >
-                <svg
-                  width="86"
-                  height="64"
-                  viewBox="0 0 104 76"
-                  fill="none"
-                  aria-hidden="true"
-                  style={{
-                    display: 'block',
-                    maxWidth: isInsideGroup ? '26%' : '24%',
-                    height: 'auto',
-                    color: isFailed
-                      ? 'rgba(255,107,115,0.22)'
-                      : isEmptySlot
-                        ? emptySlotAccent
-                        : PLACEHOLDER_COLOR,
-                    opacity: isEmptySlot ? 0.42 : isInsideGroup ? 0.72 : 1,
-                  }}
-                >
-                  <circle cx="72.5" cy="17.5" r="8.5" fill="currentColor" />
-                  <path
-                    d="M8.55 64.5C5.95 64.5 4.34 61.71 5.64 59.47L39.26 10.48C40.54 8.28 43.72 8.28 45 10.48L67.12 48.44L75.04 35.66C76.37 33.52 79.52 33.58 80.77 35.77L99.3 59.61C100.55 61.86 98.93 64.5 96.37 64.5H8.55Z"
-                    fill="currentColor"
+                {isAnalysis ? (
+                  <ScanSearch
+                    aria-hidden="true"
+                    className="size-12 text-[var(--beat-graph)] opacity-40"
+                    strokeWidth={1.35}
                   />
-                </svg>
+                ) : (
+                  <svg
+                    width="86"
+                    height="64"
+                    viewBox="0 0 104 76"
+                    fill="none"
+                    aria-hidden="true"
+                    style={{
+                      display: 'block',
+                      maxWidth: isInsideGroup ? '26%' : '24%',
+                      height: 'auto',
+                      color: isFailed
+                        ? 'rgba(255,107,115,0.22)'
+                        : isEmptySlot
+                          ? emptySlotAccent
+                          : PLACEHOLDER_COLOR,
+                      opacity: isEmptySlot ? 0.42 : isInsideGroup ? 0.72 : 1,
+                    }}
+                  >
+                    <circle cx="72.5" cy="17.5" r="8.5" fill="currentColor" />
+                    <path
+                      d="M8.55 64.5C5.95 64.5 4.34 61.71 5.64 59.47L39.26 10.48C40.54 8.28 43.72 8.28 45 10.48L67.12 48.44L75.04 35.66C76.37 33.52 79.52 33.58 80.77 35.77L99.3 59.61C100.55 61.86 98.93 64.5 96.37 64.5H8.55Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                )}
                 {isFailed && (
                   <div
                     style={{

--- a/src/components/beatcanvas/react-flow/beatcanvas-react-flow-types.ts
+++ b/src/components/beatcanvas/react-flow/beatcanvas-react-flow-types.ts
@@ -36,6 +36,7 @@ export type GenerationCardNodeProps = {
   isAnalysis?: boolean;
   latestOutputUrl?: string | null;
   latestOutputText?: string | null;
+  analysisReportCount?: number;
   takes?: GenerationTake[];
 };
 

--- a/src/components/beatcanvas/use-beatcanvas-react-flow-adapter.test.ts
+++ b/src/components/beatcanvas/use-beatcanvas-react-flow-adapter.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import type {
@@ -7,6 +8,7 @@ import type {
 } from '@/core/beatcanvas/canvas-types';
 
 import {
+  buildAnalysisReportNodeProps,
   buildGenerationCardPresentation,
   resolveDraftShapeSize,
 } from './use-beatcanvas-react-flow-adapter';
@@ -114,7 +116,7 @@ test('keeps the latest successful media on one generation node', () => {
   assert.equal('history' in presentation, false);
 });
 
-test('keeps the latest video analysis text on the Canvas node', () => {
+test('moves successful video analysis text into a separate report node', () => {
   const draft = {
     ...makeDraft('video', '16:9'),
     generationMode: 'analysis' as const,
@@ -157,5 +159,73 @@ test('keeps the latest video analysis text on the Canvas node', () => {
 
   assert.equal(presentation.isAnalysis, true);
   assert.equal(presentation.latestOutputUrl, null);
-  assert.equal(presentation.latestOutputText, output.resultText);
+  assert.equal(presentation.latestOutputText, null);
+  assert.equal(presentation.analysisReportCount, 1);
+
+  const reportProps = buildAnalysisReportNodeProps(output, 'Analysis report');
+  assert.deepEqual(reportProps, {
+    w: 480,
+    h: 340,
+    cardMediaType: 'video',
+    label: 'Analysis report',
+    status: 'succeeded',
+    isAnalysis: true,
+    latestOutputUrl: null,
+    latestOutputText: output.resultText,
+    analysisReportCount: 0,
+    takes: [],
+  });
+});
+
+test('does not materialize pending or media outputs as analysis reports', () => {
+  const draft = {
+    ...makeDraft('video', '16:9'),
+    generationMode: 'analysis' as const,
+    modelId: 'video-analysis',
+  };
+  const pendingOutput: CanvasOutputCard = {
+    ...draft,
+    id: 'output:pending-analysis',
+    kind: 'output',
+    name: 'Pending analysis',
+    resultText: null,
+    status: 'processing',
+    referenceCardIds: [draft.id],
+    sourceConfigCardId: draft.id,
+    generationRunId: 'run:pending-analysis',
+    generationSnapshot: {
+      type: 'video',
+      generationMode: 'analysis',
+      prompt: 'Analyze this video.',
+      referenceCardIds: ['asset:video'],
+      workflowTemplateId: null,
+      modelId: 'video-analysis',
+      aspectRatio: '16:9',
+      outputQuality: '720p',
+      duration: '5s',
+      mode: 'quality',
+      variant: 'standard',
+      quality: 'standard',
+      capturedAt: '2026-08-25T00:00:00.000Z',
+    },
+  };
+
+  assert.equal(
+    buildAnalysisReportNodeProps(pendingOutput, 'Analysis report'),
+    null
+  );
+});
+
+test('materializes and connects a completed analysis report after its source node', () => {
+  const source = readFileSync(
+    new URL('./use-beatcanvas-react-flow-adapter.ts', import.meta.url),
+    'utf8'
+  );
+
+  assert.match(
+    source,
+    /createConnectorBetweenCards\(draftCard\.id, outputCard\.id\)/
+  );
+  assert.match(source, /resultText: isAnalysisOutput \? null : resultText/);
+  assert.match(source, /studioT\('canvas\.shapes\.analysisReport'\)/);
 });

--- a/src/components/beatcanvas/use-beatcanvas-react-flow-adapter.ts
+++ b/src/components/beatcanvas/use-beatcanvas-react-flow-adapter.ts
@@ -44,6 +44,7 @@ import {
   ASSET_CARD_NODE_TYPE,
   GENERATION_CARD_NODE_TYPE,
   type BeatCanvasEditor,
+  type GenerationCardNodeProps,
 } from './react-flow/beatcanvas-react-flow-types';
 import type { StudioTranslateFn } from './beatcanvas-types';
 
@@ -68,6 +69,7 @@ const CARD_SOURCE_META_KEY = 'visugenCardSource';
 const CARD_WORKFLOW_TEMPLATE_META_KEY = 'visugenWorkflowTemplateId';
 const CARD_RESULT_SIZE = 360;
 const VIDEO_FRAME_HEIGHT = 236;
+const ANALYSIS_REPORT_FRAME_SIZE = { w: 480, h: 340 } as const;
 
 const makeId = () => Math.random().toString(36).slice(2, 10);
 
@@ -195,21 +197,56 @@ export const buildGenerationCardPresentation = ({
         Boolean(output.url || output.resultText)
     );
   const isAnalysis = card.generationMode === 'analysis';
+  const analysisReportCount = isAnalysis
+    ? orderedOutputs.filter(
+        (output) => output.status === 'succeeded' && Boolean(output.resultText)
+      ).length
+    : 0;
 
   return {
     status: latestOutput?.status ?? card.status,
     isAnalysis,
-    latestOutputUrl:
-      pinnedOutput?.url ?? latestSucceededOutput?.url ?? card.url ?? null,
+    latestOutputUrl: isAnalysis
+      ? null
+      : pinnedOutput?.url ?? latestSucceededOutput?.url ?? card.url ?? null,
     latestOutputText:
-      pinnedOutput?.resultText ??
-      latestSucceededOutput?.resultText ??
-      card.resultText ??
-      null,
+      isAnalysis
+        ? null
+        : pinnedOutput?.resultText ??
+          latestSucceededOutput?.resultText ??
+          card.resultText ??
+          null,
+    analysisReportCount,
     takes: buildGenerationTakes({
       outputs: orderedOutputs,
       pinnedOutputId: card.pinnedOutputId,
     }),
+  };
+};
+
+export const buildAnalysisReportNodeProps = (
+  outputCard: CanvasOutputCard,
+  label: string
+): GenerationCardNodeProps | null => {
+  if (
+    outputCard.generationSnapshot.generationMode !== 'analysis' ||
+    outputCard.status !== 'succeeded' ||
+    !outputCard.resultText
+  ) {
+    return null;
+  }
+
+  return {
+    w: ANALYSIS_REPORT_FRAME_SIZE.w,
+    h: ANALYSIS_REPORT_FRAME_SIZE.h,
+    cardMediaType: 'video',
+    label,
+    status: 'succeeded',
+    isAnalysis: true,
+    latestOutputUrl: null,
+    latestOutputText: outputCard.resultText,
+    analysisReportCount: 0,
+    takes: [],
   };
 };
 
@@ -962,13 +999,81 @@ export function useBeatCanvasReactFlowAdapter({
     ]
   );
 
+  const materializeAnalysisReport = useCallback(
+    ({
+      outputCard,
+      draftCard,
+      frame,
+      connectSource = true,
+    }: {
+      outputCard: CanvasOutputCard;
+      draftCard: CanvasDraftCard;
+      frame?: ProjectSnapshotShapeFrame;
+      connectSource?: boolean;
+    }) => {
+      const editor = editorRef.current;
+      const reportProps = buildAnalysisReportNodeProps(
+        outputCard,
+        studioT('canvas.shapes.analysisReport')
+      );
+      if (!editor || !reportProps) return false;
+
+      const reportIndex = Object.values(canvasCardsRef.current).filter(
+        (candidate) =>
+          isCanvasOutputCard(candidate) &&
+          candidate.id !== outputCard.id &&
+          candidate.sourceConfigCardId === draftCard.id &&
+          candidate.generationSnapshot.generationMode === 'analysis' &&
+          candidate.status === 'succeeded' &&
+          Boolean(candidate.resultText)
+      ).length;
+      const reportSize = frame
+        ? { w: frame.w, h: frame.h }
+        : ANALYSIS_REPORT_FRAME_SIZE;
+      const placement =
+        frame ??
+        getCanvasPlacement(
+          [draftCard.id],
+          reportIndex,
+          reportSize,
+          'right'
+        );
+
+      editor.createShape({
+        id: outputCard.id,
+        type: GENERATION_CARD_NODE_TYPE,
+        x: placement.x,
+        y: placement.y,
+        meta: {
+          [CARD_KIND_META_KEY]: 'output',
+          [CARD_TYPE_META_KEY]: 'video',
+          ...(outputCard.sourceGenerationId
+            ? { [CARD_SOURCE_META_KEY]: outputCard.sourceGenerationId }
+            : {}),
+        },
+        props: {
+          ...reportProps,
+          w: reportSize.w,
+          h: reportSize.h,
+        },
+      });
+      if (connectSource) {
+        createConnectorBetweenCards(draftCard.id, outputCard.id);
+      }
+      return true;
+    },
+    [canvasCardsRef, createConnectorBetweenCards, getCanvasPlacement, studioT]
+  );
+
   const createGenerationOutput = useCallback(
     ({
       draftCard,
       name,
       suppressFocus = false,
       shapeId,
+      frame,
       existingCard,
+      connectSource = true,
     }: {
       draftCard: CanvasDraftCard;
       name: string;
@@ -1028,7 +1133,16 @@ export function useBeatCanvasReactFlowAdapter({
       };
       setCanvasCard(nextCard);
 
-      if (!suppressFocus) {
+      const createdReportShape = materializeAnalysisReport({
+        outputCard: nextCard,
+        draftCard,
+        frame,
+        connectSource,
+      });
+
+      if (!suppressFocus && createdReportShape) {
+        focusShape(nextCard.id);
+      } else if (!suppressFocus) {
         focusShape(draftCard.id);
       }
       return outputCardId;
@@ -1037,6 +1151,7 @@ export function useBeatCanvasReactFlowAdapter({
       canvasCardsRef,
       focusShape,
       imageModels,
+      materializeAnalysisReport,
       setCanvasCard,
       videoModels,
     ]
@@ -1075,7 +1190,7 @@ export function useBeatCanvasReactFlowAdapter({
       const current = canvasCardsRef.current[outputCardId];
       if (!editorRef.current || !isCanvasOutputCard(current)) return null;
 
-      setCanvasCard({
+      const completedOutputCard: CanvasOutputCard = {
         ...current,
         name,
         url: url ?? null,
@@ -1083,18 +1198,34 @@ export function useBeatCanvasReactFlowAdapter({
         status: 'succeeded',
         error: null,
         sourceGenerationId,
-      });
+      };
+      const isAnalysisOutput =
+        completedOutputCard.generationSnapshot.generationMode === 'analysis';
+      setCanvasCard(completedOutputCard);
       setCanvasCard({
         ...draftCard,
-        url: url ?? null,
-        resultText,
+        url: isAnalysisOutput ? null : (url ?? null),
+        resultText: isAnalysisOutput ? null : resultText,
       });
-      if (!suppressFocus) {
+
+      const createdReportShape = materializeAnalysisReport({
+        outputCard: completedOutputCard,
+        draftCard,
+      });
+
+      if (!suppressFocus && createdReportShape) {
+        focusShape(completedOutputCard.id);
+      } else if (!suppressFocus) {
         focusShape(draftCard.id);
       }
       return outputCardId;
     },
-    [canvasCardsRef, focusShape, setCanvasCard]
+    [
+      canvasCardsRef,
+      focusShape,
+      materializeAnalysisReport,
+      setCanvasCard,
+    ]
   );
 
   const createDraftCard = useCallback(
@@ -1326,7 +1457,7 @@ export function useBeatCanvasReactFlowAdapter({
           shapeId: item.card.id,
           frame: item.frame,
           existingCard: item.card,
-          connectSource: false,
+          connectSource: true,
         });
         if (insertedOutputCardId) {
           restoredCardIds.push(insertedOutputCardId);
@@ -1479,6 +1610,35 @@ export function useBeatCanvasReactFlowAdapter({
 
     syncedAssetShapeSignaturesRef.current = nextSignatures;
   }, [canvasCards, syncAssetShape]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    const visibleReportIds = new Set(
+      Object.values(canvasCards)
+        .filter(
+          (card): card is CanvasOutputCard =>
+            isCanvasOutputCard(card) &&
+            card.generationSnapshot.generationMode === 'analysis' &&
+            card.status === 'succeeded' &&
+            Boolean(card.resultText)
+        )
+        .map((card) => card.id)
+    );
+    const orphanedReportShapeIds = editor
+      .getCurrentPageShapes()
+      .filter(
+        (shape) =>
+          shape.meta[CARD_KIND_META_KEY] === 'output' &&
+          !visibleReportIds.has(shape.id)
+      )
+      .map((shape) => shape.id);
+
+    if (orphanedReportShapeIds.length > 0) {
+      editor.deleteShapes(orphanedReportShapeIds);
+    }
+  }, [canvasCards]);
 
   const deleteCanvasCard = useCallback(
     (cardId: string) => {

--- a/src/core/effects/generation-upload-intent.test.ts
+++ b/src/core/effects/generation-upload-intent.test.ts
@@ -8,7 +8,9 @@ import {
   claimGenerationUploadSlot,
   completeGenerationUploadSlot,
   consumeGenerationUploadIntent,
+  failGenerationUploadIntent,
   GenerationIntentQuotaError,
+  getGenerationUploadIntentAdmissionState,
   issueGenerationUploadIntent,
 } from './generation-upload-intent';
 
@@ -222,6 +224,86 @@ test('zero-upload intents remain valid once and expired intents are rejected', a
         dbClient: db,
       }),
       null
+    );
+  } finally {
+    client.close();
+  }
+});
+
+test('classifies intent failures so only safe zero-upload expiry can auto-refresh', async () => {
+  const { client, db } = await createTestDb();
+  try {
+    const zeroUploadId = await issueGenerationUploadIntent({
+      projectId: 'project-1',
+      effectId: 401,
+      expectedUploadCount: 0,
+      now: new Date(1_000),
+      dbClient: db,
+    });
+    assert.deepEqual(
+      await getGenerationUploadIntentAdmissionState({
+        intentId: zeroUploadId,
+        projectId: 'project-1',
+        effectId: 401,
+        now: new Date(601_000),
+        dbClient: db,
+      }),
+      { status: 'expired', refreshableWithoutUploads: true }
+    );
+
+    const uploadIntentId = await issueGenerationUploadIntent({
+      projectId: 'project-1',
+      effectId: 402,
+      expectedUploadCount: 1,
+      now: new Date(1_000),
+      dbClient: db,
+    });
+    assert.deepEqual(
+      await getGenerationUploadIntentAdmissionState({
+        intentId: uploadIntentId,
+        projectId: 'project-1',
+        effectId: 402,
+        now: new Date(2_000),
+        dbClient: db,
+      }),
+      { status: 'incomplete', expectedUploadCount: 1 }
+    );
+
+    assert.ok(
+      await consumeGenerationUploadIntent({
+        intentId: zeroUploadId,
+        projectId: 'project-1',
+        effectId: 401,
+        referencedUrls: [],
+        now: new Date(2_000),
+        dbClient: db,
+      })
+    );
+    assert.deepEqual(
+      await getGenerationUploadIntentAdmissionState({
+        intentId: zeroUploadId,
+        projectId: 'project-1',
+        effectId: 401,
+        now: new Date(3_000),
+        dbClient: db,
+      }),
+      { status: 'used' }
+    );
+
+    await failGenerationUploadIntent({
+      intentId: uploadIntentId,
+      now: new Date(3_000),
+      dbClient: db,
+    });
+    assert.deepEqual(
+      await getGenerationUploadIntentAdmissionState({
+        intentId: uploadIntentId,
+        projectId: 'project-1',
+        effectId: 402,
+        now: new Date(4_000),
+        dbClient: db,
+      }),
+      { status: 'invalid' }
     );
   } finally {
     client.close();

--- a/src/core/effects/generation-upload-intent.ts
+++ b/src/core/effects/generation-upload-intent.ts
@@ -55,6 +55,66 @@ export const normalizeExpectedUploadCount = (value: unknown) => {
   return count >= 0 && count <= MAX_GENERATION_UPLOADS ? count : null;
 };
 
+export type GenerationUploadIntentAdmissionState =
+  | { status: 'missing' | 'invalid' | 'used' }
+  | { status: 'expired'; refreshableWithoutUploads: boolean }
+  | { status: 'incomplete' | 'ready'; expectedUploadCount: number };
+
+export async function getGenerationUploadIntentAdmissionState({
+  intentId,
+  projectId,
+  effectId,
+  now = new Date(),
+  dbClient,
+}: {
+  intentId: string;
+  projectId: string;
+  effectId: number;
+  now?: Date;
+  dbClient?: DbClient;
+}): Promise<GenerationUploadIntentAdmissionState> {
+  const db = await resolveDb(dbClient);
+  const rows = await db
+    .select()
+    .from(generationUploadIntent)
+    .where(eq(generationUploadIntent.id, intentId))
+    .limit(1);
+  const intent = rows[0];
+
+  if (!intent) return { status: 'missing' };
+  if (intent.projectId !== projectId || intent.effectId !== effectId) {
+    return { status: 'invalid' };
+  }
+  if (intent.status === 'submitting' || intent.status === 'consumed') {
+    return { status: 'used' };
+  }
+  if (intent.status !== 'pending') {
+    return { status: 'invalid' };
+  }
+  if (intent.expiresAt <= now) {
+    return {
+      status: 'expired',
+      refreshableWithoutUploads:
+        intent.expectedUploadCount === 0 &&
+        intent.reservedUploadCount === 0 &&
+        intent.completedUploadCount === 0,
+    };
+  }
+  if (
+    intent.reservedUploadCount !== intent.expectedUploadCount ||
+    intent.completedUploadCount !== intent.expectedUploadCount
+  ) {
+    return {
+      status: 'incomplete',
+      expectedUploadCount: intent.expectedUploadCount,
+    };
+  }
+  return {
+    status: 'ready',
+    expectedUploadCount: intent.expectedUploadCount,
+  };
+}
+
 export async function issueGenerationUploadIntent({
   projectId,
   effectId,

--- a/src/core/effects/project-reference-authorization.test.ts
+++ b/src/core/effects/project-reference-authorization.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { CanvasCard } from '@/core/beatcanvas/canvas-types';
+import type { ProjectSnapshotDocument } from '@/core/projects/project-snapshot';
+import { resolveAuthorizedProjectReferenceUrls } from './project-reference-authorization';
+
+const card = ({
+  id,
+  kind,
+  url,
+}: {
+  id: string;
+  kind: CanvasCard['kind'];
+  url: string | null;
+}): CanvasCard =>
+  ({
+    id,
+    assetId: null,
+    kind,
+    type: 'video',
+    name: id,
+    url,
+    resultText: null,
+    prompt: '',
+    referenceCardIds: [],
+    workflowTemplateId: null,
+    status: 'idle',
+    error: null,
+    modelId: '',
+    aspectRatio: '16:9',
+    outputQuality: '1k',
+    duration: '5s',
+    mode: 'quality',
+    variant: 'standard',
+    quality: 'standard',
+    sourceGenerationId: null,
+    sourceConfigCardId: null,
+    generationRunId: null,
+    generationSnapshot: null,
+    pinnedOutputId: null,
+  }) as CanvasCard;
+
+test('treats saved canvas media as project-authorized generation references', () => {
+  const canvasVideo = 'https://media.beatapi.io/inputs/canvas-video.mp4';
+  const projectImage = 'https://media.beatapi.io/outputs/project-image.png';
+  const unrelated = 'https://attacker.example/unrelated.mp4';
+  const snapshot: ProjectSnapshotDocument = {
+    version: 3,
+    cards: [
+      card({ id: 'canvas-video', kind: 'asset', url: canvasVideo }),
+      card({ id: 'unused-output', kind: 'output', url: unrelated }),
+    ],
+    frames: {},
+  };
+
+  assert.deepEqual(
+    resolveAuthorizedProjectReferenceUrls({
+      referencedUrls: [canvasVideo, projectImage],
+      projectAssetUrls: [projectImage, projectImage],
+      snapshot,
+    }),
+    [projectImage, canvasVideo]
+  );
+});
+
+test('does not authorize a URL merely because another canvas URL is trusted', () => {
+  const canvasVideo = 'https://media.beatapi.io/inputs/canvas-video.mp4';
+  const unknown = 'https://attacker.example/unknown.mp4';
+  const snapshot: ProjectSnapshotDocument = {
+    version: 3,
+    cards: [card({ id: 'canvas-video', kind: 'generation', url: canvasVideo })],
+    frames: {},
+  };
+
+  assert.deepEqual(
+    resolveAuthorizedProjectReferenceUrls({
+      referencedUrls: [unknown],
+      projectAssetUrls: [],
+      snapshot,
+    }),
+    []
+  );
+});

--- a/src/core/effects/project-reference-authorization.ts
+++ b/src/core/effects/project-reference-authorization.ts
@@ -1,0 +1,32 @@
+import type { ProjectSnapshotDocument } from '@/core/projects/project-snapshot';
+
+export const resolveAuthorizedProjectReferenceUrls = ({
+  referencedUrls,
+  projectAssetUrls,
+  snapshot,
+}: {
+  referencedUrls: string[];
+  projectAssetUrls: string[];
+  snapshot: ProjectSnapshotDocument | null | undefined;
+}) => {
+  const referenced = new Set(
+    referencedUrls.map((url) => url.trim()).filter(Boolean)
+  );
+  const authorized = new Set<string>();
+
+  for (const url of projectAssetUrls) {
+    const normalizedUrl = url.trim();
+    if (referenced.has(normalizedUrl)) {
+      authorized.add(normalizedUrl);
+    }
+  }
+
+  for (const card of snapshot?.cards ?? []) {
+    const normalizedUrl = card.url?.trim();
+    if (normalizedUrl && referenced.has(normalizedUrl)) {
+      authorized.add(normalizedUrl);
+    }
+  }
+
+  return [...authorized];
+};

--- a/src/core/effects/submit-generation.ts
+++ b/src/core/effects/submit-generation.ts
@@ -19,16 +19,22 @@ import {
 } from '@/core/effects/record-generation';
 import { startBackendPollingForGeneration } from '@/core/effects/server-poller';
 import { withGenerationSubmissionLock } from '@/core/effects/generation-submission-lock';
+import { resolveAuthorizedProjectReferenceUrls } from '@/core/effects/project-reference-authorization';
 import {
   getGenerationPromptConstraints,
   validateGenerationPrompt,
 } from '@/core/effects/validation';
-import { getProject } from '@/core/projects/projects';
+import {
+  getProject,
+  loadProjectWithLatestSnapshot,
+} from '@/core/projects/projects';
 import {
   completeGenerationUploadIntent,
   consumeGenerationUploadIntent,
   failGenerationUploadIntent,
   getCompletedIntentUploads,
+  getGenerationUploadIntentAdmissionState,
+  issueGenerationUploadIntent,
 } from '@/core/effects/generation-upload-intent';
 import {
   linkGenerationAsset,
@@ -188,7 +194,7 @@ export async function submitEffectGeneration({
     : adapterInput;
   const admission = await withGenerationSubmissionLock<
     | { result: SubmitEffectGenerationResult }
-    | { generationId: string }
+    | { generationId: string; intentId: string }
   >(async () => {
     const [activeProjectId, runningCount] = await Promise.all([
       findActiveProject(),
@@ -235,25 +241,94 @@ export async function submitEffectGeneration({
         } satisfies SubmitEffectGenerationResult,
       };
     }
-    const authorizedProjectUrls = await getProjectAssetUrls({
-      projectId: normalizedProjectId,
-      urls: referencedUrls,
+    const [projectAssetUrls, projectState] = await Promise.all([
+      getProjectAssetUrls({
+        projectId: normalizedProjectId,
+        urls: referencedUrls,
+      }),
+      loadProjectWithLatestSnapshot({ projectId: normalizedProjectId }),
+    ]);
+    const authorizedProjectUrls = resolveAuthorizedProjectReferenceUrls({
+      referencedUrls,
+      projectAssetUrls,
+      snapshot: projectState?.snapshot,
     });
-    const intent = await consumeGenerationUploadIntent({
-      intentId: normalizedIntentId,
+    let admittedIntentId = normalizedIntentId;
+    let intent = await consumeGenerationUploadIntent({
+      intentId: admittedIntentId,
       projectId: normalizedProjectId,
       effectId,
       referencedUrls,
       authorizedProjectUrls,
     });
+    let intentState = intent
+      ? null
+      : await getGenerationUploadIntentAdmissionState({
+          intentId: admittedIntentId,
+          projectId: normalizedProjectId,
+          effectId,
+        });
+    if (
+      !intent &&
+      intentState?.status === 'expired' &&
+      intentState.refreshableWithoutUploads
+    ) {
+      await failGenerationUploadIntent({ intentId: admittedIntentId });
+      admittedIntentId = await issueGenerationUploadIntent({
+        projectId: normalizedProjectId,
+        effectId,
+        expectedUploadCount: 0,
+      });
+      intent = await consumeGenerationUploadIntent({
+        intentId: admittedIntentId,
+        projectId: normalizedProjectId,
+        effectId,
+        referencedUrls,
+        authorizedProjectUrls,
+      });
+      intentState = intent
+        ? null
+        : await getGenerationUploadIntentAdmissionState({
+            intentId: admittedIntentId,
+            projectId: normalizedProjectId,
+            effectId,
+          });
+    }
     if (!intent) {
+      // Only retire an otherwise valid pending intent that failed reference
+      // authorization. A submitting intent may belong to an in-flight paid
+      // request, while an incomplete one may still have uploads finishing.
+      if (intentState?.status === 'ready') {
+        await failGenerationUploadIntent({ intentId: admittedIntentId });
+      }
+      const failure =
+        intentState?.status === 'used'
+          ? {
+              code: 'GENERATION_ALREADY_SUBMITTED',
+              error:
+                'This generation was already submitted. Check History before trying again.',
+            }
+          : intentState?.status === 'incomplete'
+            ? {
+                code: 'GENERATION_REFERENCES_PREPARING',
+                error:
+                  'A reference file is still being prepared. Wait a moment and try Generate again.',
+              }
+            : intentState?.status === 'ready'
+              ? {
+                  code: 'GENERATION_REFERENCE_NOT_AUTHORIZED',
+                  error:
+                    'A reference is no longer available in this canvas. Re-add it and try Generate again.',
+                }
+              : {
+                  code: 'GENERATION_REQUEST_CHANGED',
+                  error:
+                    'The generation request changed before submission. Try Generate again.',
+                };
       return {
         result: {
           status: 409,
-          body: {
-            error:
-              'Generation intent is invalid, expired, incomplete, or already used.',
-          },
+          body: failure,
         } satisfies SubmitEffectGenerationResult,
       };
     }
@@ -265,7 +340,7 @@ export async function submitEffectGeneration({
       input: recordedInput,
     });
     if (!generationId) {
-      await failGenerationUploadIntent({ intentId: normalizedIntentId });
+      await failGenerationUploadIntent({ intentId: admittedIntentId });
       return {
         result: {
           status: 500,
@@ -273,10 +348,10 @@ export async function submitEffectGeneration({
         } satisfies SubmitEffectGenerationResult,
       };
     }
-    return { generationId };
+    return { generationId, intentId: admittedIntentId };
   });
   if ('result' in admission) return admission.result;
-  const { generationId } = admission;
+  const { generationId, intentId } = admission;
 
   try {
     await linkInputAssets(generationId, adapterInput);
@@ -299,10 +374,10 @@ export async function submitEffectGeneration({
           })
         : transition.output;
     if (result.status === 'failed') {
-      await failGenerationUploadIntent({ intentId: normalizedIntentId });
+      await failGenerationUploadIntent({ intentId });
     } else {
       await finalizeIntentUploads({
-        intentId: normalizedIntentId,
+        intentId,
         generationId,
       });
     }
@@ -327,7 +402,7 @@ export async function submitEffectGeneration({
     };
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : 'Generation failed';
-    await failGenerationUploadIntent({ intentId: normalizedIntentId });
+    await failGenerationUploadIntent({ intentId });
     await updateGenerationById({ id: generationId, status: 'failed', error: message });
     return { status: 500, body: { error: message } };
   }


### PR DESCRIPTION
## Summary
- add Preview and Download actions to generated image and video results, including double-click image preview
- materialize completed video-analysis text as a separate selectable report node
- authorize saved project media precisely and refresh only safe expired zero-upload generation intents
- keep analysis, placeholder, and unauthorized media outside preview/submission paths

## Verification
- `pnpm test` — 250/250 passed
- `pnpm typecheck` — passed
- `pnpm i18n:check` — 568 English / 568 Chinese keys
- `pnpm build` — passed
- staged security scan — clean for both commits
- local canvas QA — generated image toolbar and enlarged Preview confirmed

## Safety
- no credentials, environment files, database files, generated output, or paid provider runs included
- release is limited to the open-source `BeatAPI/BeatDesign` workspace
